### PR TITLE
Proposal Table with MaterialUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orakwlum-frontend",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -106,6 +106,7 @@ export class Proposal extends Component {
 
         const lastExecution = new Date(proposal.execution_date).toLocaleString(locale, hourOptions);
         const creationDate = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
+        const ownerText = (proposal.owner)?"by " + proposal.owner:"";
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
         const subtitle = <span>{daysRange}</span>;
@@ -164,7 +165,7 @@ export class Proposal extends Component {
 
 
           {       proposal.creation_date &&
-                  <p><span>Proposal was created on {creationDate}</span></p>
+                  <p><span>Proposal was created on {creationDate} {ownerText}</span></p>
           }
 
           {       proposal.execution_date &&

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -95,6 +95,7 @@ export class Proposal extends Component {
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
         const subtitle = <span>{daysRange}</span>;
 
+
         const Proposal = () => (
             <Card>
               <CardTitle title={title} subtitle={subtitle} />
@@ -118,7 +119,7 @@ export class Proposal extends Component {
                   {
                   proposal.aggregations.map( function(agg, i) {
                       return (
-                           <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} />
+                           <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
                        );
                   })
                   }

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -38,8 +38,13 @@ const styles = {
       margin: 4,
     },
     wrapper: {
-      display: 'flex',
+        display: 'flex',
     },
+
+    aggregations: {
+        display: 'flex',
+    },
+
     toggle: {
         marginTop: 7,
       marginLeft: 7,
@@ -112,8 +117,75 @@ export class Proposal extends Component {
         const creationDate = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
         const ownerText = (proposal.owner)?"by " + proposal.owner:"";
 
+        const withPicture = (proposal.isNew)?!proposal.isNew:true;
+
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
-        const subtitle = <span>{daysRange}</span>;
+        const subtitle = <span>{daysRange + withPicture}</span>;
+
+        const offset = (withPicture)?0:1;
+        const size = (withPicture)?8:9;
+
+        const proposalStatus = (
+            proposal.status &&
+            <div className={"col-md-2 col-lg-2"} style={styles.wrapper}>
+                <ProposalTag tag={proposal.status} />
+            </div>
+        )
+
+        const proposalAggregations = (
+            proposal.aggregations &&
+                <div id="aggregationsList" className={"col-md-offset-"+ (offset) + " col-md-" + size + " col-lg-offset-"+ (offset) + " col-lg-" + size} style={styles.aggregations}>
+                {
+                    proposal.aggregations.map( function(agg, i) {
+                        return (
+                             <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
+                         );
+                    })
+                }
+                </div>
+
+        )
+
+        const proposalPictureToggle = (
+            (withPicture) &&
+            <div className="col-xs-offset-0 col-xs-2 col-sm-offset-0 col-sm-1 col-md-1 col-md-offset-0 col-lg-offset-0 col-lg-1" style={styles.toRight}>
+              {
+              (proposalTable)?
+                  <Toggle
+                      label="Chart"
+                      labelPosition="left"
+                      onToggle={this.toogleProposalRender}
+                      style={styles.toggle}
+                      toggled={proposalTable}
+                  />
+              :
+                  <Toggle
+                      label="Table"
+                      labelPosition="right"
+                      onToggle={this.toogleProposalRender}
+                      style={styles.toggle}
+                      toggled={proposalTable}
+                  />
+              }
+            </div>
+            )
+
+
+
+
+
+        const proposalPicture =
+            (withPicture)?
+                (proposal.prediction) &&
+                  (proposalTable)?
+                      <ProposalTableMaterial stacked={true} proposal={proposal} height={500} />
+                      :
+                      <ProposalGraph stacked={true} proposal={proposal} height={500} />
+                  :null
+
+
+
+        console.log(withPicture);
 
         const Proposal = () => (
             <Card>
@@ -127,47 +199,11 @@ export class Proposal extends Component {
 
 
                   <div className="row">
-                  {
-                      proposal.status &&
-                      <div className="col-md-3 col-lg-4" style={styles.wrapper}>
-                          <ProposalTag tag={proposal.status} />
-                      </div>
-                  }
+                      {proposalStatus}
 
-                  {
-                      proposal.aggregations &&
-                      <div>
-                          <div className="col-md-offset-1 col-md-5 col-lg-offset-0 col-lg-4" style={styles.wrapper}>
-                          {
-                              proposal.aggregations.map( function(agg, i) {
-                                  return (
-                                       <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
-                                   );
-                              })
-                          }
-                          </div>
-                          <div className="col-xs-offset-0 col-xs-2 col-sm-offset-0 col-sm-1 col-md-1 col-md-offset-1 col-lg-offset-2 col-lg-1" style={styles.toRight}>
-                            {
-                            (proposalTable)?
-                                <Toggle
-                                    label="Chart"
-                                    labelPosition="left"
-                                    onToggle={this.toogleProposalRender}
-                                    style={styles.toggle}
-                                    toggled={proposalTable}
-                                />
-                            :
-                                <Toggle
-                                    label="Table"
-                                    labelPosition="right"
-                                    onToggle={this.toogleProposalRender}
-                                    style={styles.toggle}
-                                    toggled={proposalTable}
-                                />
-                            }
-                          </div>
-                      </div>
-                  }
+                      {proposalAggregations}
+
+                      {proposalPictureToggle}
                   </div>
 
               <CardText>
@@ -182,13 +218,7 @@ export class Proposal extends Component {
           }
               </CardText>
 
-          {
-              proposal.prediction &&
-                (proposalTable)?
-                    <ProposalTableMaterial stacked={true} proposal={proposal} height={500} />
-                    :
-                    <ProposalGraph stacked={true} proposal={proposal} height={500} />
-          }
+          {proposalPicture}
 
           {
               !readOnly &&

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -11,6 +11,7 @@ import Avatar from 'material-ui/Avatar';
 import Chip from 'material-ui/Chip';
 import {orange300, orange900, green300, green900, red300, red900} from 'material-ui/styles/colors';
 
+import Toggle from 'material-ui/Toggle';
 
 import * as actionCreators from '../../actions/proposal';
 
@@ -32,7 +33,6 @@ const hourOptions = {
     minute: '2-digit',
 };
 
-
 const styles = {
     chip: {
       margin: 4,
@@ -40,6 +40,9 @@ const styles = {
     wrapper: {
       display: 'flex',
       flexWrap: 'wrap',
+    },
+    toggle: {
+      marginBottom: 16,
     },
 };
 
@@ -87,6 +90,12 @@ export class Proposal extends Component {
         browserHistory.push(route);
     }
 
+    toogleProposalRender = (event, status) => {
+        this.setState({
+            proposalTable: status,
+        });
+    };
+
     render() {
         const readOnly = (this.props.readOnly)?this.props.readOnly:false;
         const proposal = this.state.proposal;
@@ -98,7 +107,6 @@ export class Proposal extends Component {
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
         const subtitle = <span>{daysRange}</span>;
-
 
         const Proposal = () => (
             <Card>
@@ -120,18 +128,37 @@ export class Proposal extends Component {
           {
               proposal.aggregations &&
               <div style={styles.wrapper}>
-                  {
+              {
                   proposal.aggregations.map( function(agg, i) {
                       return (
                            <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
                        );
                   })
-                  }
+              }
+                <div>
+                {
+                (proposalTable)?
+                    <Toggle
+                        label="Chart"
+                        labelPosition="left"
+                        style={styles.toggle}
+                        onToggle={this.toogleProposalRender}
+                        toggled={proposalTable}
+                    />
+                :
+                    <Toggle
+                        label="Table"
+                        labelPosition="right"
+                        style={styles.toggle}
+                        onToggle={this.toogleProposalRender}
+                        toggled={proposalTable}
+                    />
+                }
+                </div>
               </div>
           }
 
               <CardText>
-
           {       proposal.executionDate &&
                   <span>Last execution was done at {lastExecution}</span>
           }
@@ -160,10 +187,6 @@ export class Proposal extends Component {
 
         return (
             <div>
-
-                <div>
-                </div>
-
                 <Proposal/>
             </div>
         );

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -90,7 +90,7 @@ export class Proposal extends Component {
         const proposal = this.state.proposal;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
-        const lastExecution = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
+        const lastExecution = new Date(proposal.executionDate).toLocaleString(locale, hourOptions);
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
         const subtitle = <span>{daysRange}</span>;
@@ -126,7 +126,10 @@ export class Proposal extends Component {
           }
 
               <CardText>
-                  Last execution was done at {lastExecution}
+
+          {       proposal.executionDate &&
+                  <span>Last execution was done at {lastExecution}</span>
+          }
               </CardText>
 
           {

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -44,6 +44,9 @@ const styles = {
     toggle: {
       marginBottom: 16,
     },
+    toRight: {
+        textAlign: 'right',
+    }
 };
 
 const colors = {
@@ -122,44 +125,49 @@ export class Proposal extends Component {
                   </CardMedia>
 
 
-          {
-              proposal.status &&
-              <div style={styles.wrapper}>
-                  <ProposalTag tag={proposal.status} />
-              </div>
-          }
-          {
-              proposal.aggregations &&
-              <div style={styles.wrapper}>
-              {
-                  proposal.aggregations.map( function(agg, i) {
-                      return (
-                           <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
-                       );
-                  })
-              }
-                <div>
-                {
-                (proposalTable)?
-                    <Toggle
-                        label="Chart"
-                        labelPosition="left"
-                        style={styles.toggle}
-                        onToggle={this.toogleProposalRender}
-                        toggled={proposalTable}
-                    />
-                :
-                    <Toggle
-                        label="Table"
-                        labelPosition="right"
-                        style={styles.toggle}
-                        onToggle={this.toogleProposalRender}
-                        toggled={proposalTable}
-                    />
-                }
-                </div>
-              </div>
-          }
+                  <div className="row">
+                  {
+                      proposal.status &&
+                      <div className="col-md-4" style={styles.wrapper}>
+                          <ProposalTag tag={proposal.status} />
+                      </div>
+                  }
+
+                  {
+                      proposal.aggregations &&
+                      <div>
+                          <div className="col-md-4" style={styles.wrapper}>
+                          {
+                              proposal.aggregations.map( function(agg, i) {
+                                  return (
+                                       <ProposalTag key={"aggregationTag_"+i} tag={agg.lite} readOnly/>
+                                   );
+                              })
+                          }
+                          </div>
+                          <div className="col-md-2 col-md-offset-2 col-sm-offset-0 col-lg-offset-2" style={styles.wrapper}>
+                            {
+                            (proposalTable)?
+                                <Toggle
+                                    label="Chart"
+                                    labelPosition="left"
+                                    style={styles.toggle}
+                                    onToggle={this.toogleProposalRender}
+                                    toggled={proposalTable}
+                                />
+                            :
+                                <Toggle
+                                    label="Table"
+                                    labelPosition="right"
+                                    style={styles.toggle}
+                                    onToggle={this.toogleProposalRender}
+                                    toggled={proposalTable}
+                                />
+                            }
+                          </div>
+                      </div>
+                  }
+                  </div>
 
               <CardText>
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -79,6 +79,7 @@ export class Proposal extends Component {
         super(props);
         this.state = {
             proposal: props.proposal,
+            proposalTable: false,
         };
     }
 
@@ -89,6 +90,8 @@ export class Proposal extends Component {
     render() {
         const readOnly = (this.props.readOnly)?this.props.readOnly:false;
         const proposal = this.state.proposal;
+
+        const proposalTable = this.state.proposalTable;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
         const lastExecution = new Date(proposal.executionDate).toLocaleString(locale, hourOptions);
@@ -136,12 +139,10 @@ export class Proposal extends Component {
 
           {
               proposal.prediction &&
-              <ProposalGraph stacked={true} proposal={proposal} height={500} />
-          }
-
-          {
-              proposal.prediction &&
-              <ProposalTableMaterial stacked={true} proposal={proposal} height={500} />
+                (proposalTable)?
+                    <ProposalTableMaterial stacked={true} proposal={proposal} height={500} />
+                    :
+                    <ProposalGraph stacked={true} proposal={proposal} height={500} />
           }
 
           {

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -41,10 +41,13 @@ const styles = {
         display: 'flex',
     },
 
+    aggregationsLeft: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+    },
     aggregations: {
         display: 'flex',
     },
-
     toggle: {
         marginTop: 7,
       marginLeft: 7,
@@ -132,9 +135,11 @@ export class Proposal extends Component {
             </div>
         )
 
+        const aggregationsStyle = (withPicture)?styles.aggregations:styles.aggregationsLeft;
+
         const proposalAggregations = (
             proposal.aggregations &&
-                <div id="aggregationsList" className={"col-md-offset-"+ (offset) + " col-md-" + size + " col-lg-offset-"+ (offset) + " col-lg-" + size} style={styles.aggregations}>
+                <div id="aggregationsList" className={"col-md-offset-"+ (offset) + " col-md-" + size + " col-lg-offset-"+ (offset) + " col-lg-" + size} style={aggregationsStyle}>
                 {
                     proposal.aggregations.map( function(agg, i) {
                         return (

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -40,21 +40,23 @@ const styles = {
     wrapper: {
         display: 'flex',
     },
-
-    aggregationsLeft: {
+    aggregationsRight: {
         display: 'flex',
         justifyContent: 'flex-end',
+    },
+    aggregationsCenter: {
+        display: 'flex',
+        justifyContent: 'center',
     },
     aggregations: {
         display: 'flex',
     },
     toggle: {
-        marginTop: 7,
-      marginLeft: 7,
-      textAlign: "right",
+      marginTop: 7,
     },
-    toRight: {
-        textAlign: "right",
+    labelToggle: {
+        marginTop: 7,
+        marginLeft: 7,
     }
 };
 
@@ -135,11 +137,14 @@ export class Proposal extends Component {
             </div>
         )
 
-        const aggregationsStyle = (withPicture)?styles.aggregations:styles.aggregationsLeft;
+        const aggregationsStyle = (withPicture)?styles.aggregations:styles.aggregationsRight;
 
         const proposalAggregations = (
             proposal.aggregations &&
-                <div id="aggregationsList" className={"col-md-offset-"+ (offset) + " col-md-" + size + " col-lg-offset-"+ (offset) + " col-lg-" + size} style={aggregationsStyle}>
+                <div
+                    id="aggregationsList"
+                    className={"col-md-offset-"+ (offset) + " col-md-" + size + " col-lg-offset-"+ (offset) + " col-lg-" + size}
+                    style={aggregationsStyle}>
                 {
                     proposal.aggregations.map( function(agg, i) {
                         return (
@@ -153,24 +158,50 @@ export class Proposal extends Component {
 
         const proposalPictureToggle = (
             (withPicture) &&
-            <div className="col-xs-offset-0 col-xs-2 col-sm-offset-0 col-sm-1 col-md-1 col-md-offset-0 col-lg-offset-0 col-lg-1" style={styles.toRight}>
+            <div
+                className="col-xs-offset-0 col-xs-6 col-sm-offset-0 col-sm-3 col-md-2 col-md-offset-0 col-lg-offset-0 col-lg-2"
+                style={styles.to_ri}>
               {
               (proposalTable)?
-                  <Toggle
-                      label="Chart"
-                      labelPosition="left"
-                      onToggle={this.toogleProposalRender}
-                      style={styles.toggle}
-                      toggled={proposalTable}
-                  />
+              <div
+                  id="togglePicture"
+                  className="row"
+                  style={styles.aggregationsCenter}
+              >
+                  <div className="col-xs-2" style={styles.labelToggle}>
+                      Chart
+                  </div>
+                  <div id="toogleElement" className="col-xs-3">
+                      <Toggle
+                          onToggle={this.toogleProposalRender}
+                          style={styles.toggle}
+                          toggled={proposalTable}
+                      />
+                  </div>
+                  <div className="col-xs-2" style={styles.toggle}>
+                      <b>Table</b>
+                  </div>
+              </div>
               :
-                  <Toggle
-                      label="Table"
-                      labelPosition="right"
-                      onToggle={this.toogleProposalRender}
-                      style={styles.toggle}
-                      toggled={proposalTable}
-                  />
+              <div
+                  id="togglePicture"
+                  className="row"
+                  style={styles.aggregationsCenter}
+              >
+                  <div className="col-xs-2" style={styles.labelToggle}>
+                      <b>Chart</b>
+                  </div>
+                  <div id="toogleElement" className="col-xs-3">
+                      <Toggle
+                          onToggle={this.toogleProposalRender}
+                          style={styles.toggle}
+                          toggled={proposalTable}
+                      />
+                  </div>
+                  <div className="col-xs-2" style={styles.toggle}>
+                      Table
+                  </div>
+              </div>
               }
             </div>
             )

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -103,7 +103,9 @@ export class Proposal extends Component {
         const proposalTable = this.state.proposalTable;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
-        const lastExecution = new Date(proposal.executionDate).toLocaleString(locale, hourOptions);
+
+        const lastExecution = new Date(proposal.execution_date).toLocaleString(locale, hourOptions);
+        const creationDate = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
         const subtitle = <span>{daysRange}</span>;
@@ -159,8 +161,14 @@ export class Proposal extends Component {
           }
 
               <CardText>
-          {       proposal.executionDate &&
-                  <span>Last execution was done at {lastExecution}</span>
+
+
+          {       proposal.creation_date &&
+                  <p><span>Proposal was created on {creationDate}</span></p>
+          }
+
+          {       proposal.execution_date &&
+                  <p><span>Last execution was done at {lastExecution}</span></p>
           }
               </CardText>
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -17,6 +17,12 @@ import * as actionCreators from '../../actions/proposal';
 import { ProposalTag } from '../ProposalTag';
 import { ProposalGraph } from '../ProposalGraph';
 
+const locale = 'es';
+const dateOptions = {
+    day: '2-digit',
+    year: 'numeric',
+    month: '2-digit',
+};
 
 const styles = {
     chip: {
@@ -75,13 +81,19 @@ export class Proposal extends Component {
         const readOnly = (this.props.readOnly)?this.props.readOnly:false;
         const proposal = this.state.proposal;
 
+        const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
+        const creationDate = new Date(proposal.creation_date).toLocaleString(locale, dateOptions);
+
+        const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
+        const subtitle = <span>{daysRange}<span><br/>Last execution <u>{creationDate}</u></span></span>;
+
         const Proposal = () => (
             <Card>
-              <CardTitle title={proposal.name} subtitle={<span>{new Date(proposal.creation_date).toLocaleString()}</span>} />
+              <CardTitle title={title} subtitle={subtitle} />
 
                   <CardMedia
-                    overlay={<CardTitle title={proposal.name}
-                    subtitle={<span>{new Date(proposal.creation_date).toLocaleString()}</span>} />}
+                    overlay={<CardTitle title={title}
+                    subtitle={subtitle} />}
                   >
                   </CardMedia>
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -39,13 +39,14 @@ const styles = {
     },
     wrapper: {
       display: 'flex',
-      flexWrap: 'wrap',
     },
     toggle: {
-      marginBottom: 16,
+        marginTop: 7,
+      marginLeft: 7,
+      textAlign: "right",
     },
     toRight: {
-        textAlign: 'right',
+        textAlign: "right",
     }
 };
 
@@ -128,7 +129,7 @@ export class Proposal extends Component {
                   <div className="row">
                   {
                       proposal.status &&
-                      <div className="col-md-4" style={styles.wrapper}>
+                      <div className="col-md-3 col-lg-4" style={styles.wrapper}>
                           <ProposalTag tag={proposal.status} />
                       </div>
                   }
@@ -136,7 +137,7 @@ export class Proposal extends Component {
                   {
                       proposal.aggregations &&
                       <div>
-                          <div className="col-md-4" style={styles.wrapper}>
+                          <div className="col-md-offset-1 col-md-5 col-lg-offset-0 col-lg-4" style={styles.wrapper}>
                           {
                               proposal.aggregations.map( function(agg, i) {
                                   return (
@@ -145,22 +146,22 @@ export class Proposal extends Component {
                               })
                           }
                           </div>
-                          <div className="col-md-2 col-md-offset-2 col-sm-offset-0 col-lg-offset-2" style={styles.wrapper}>
+                          <div className="col-xs-offset-0 col-xs-2 col-sm-offset-0 col-sm-1 col-md-1 col-md-offset-1 col-lg-offset-2 col-lg-1" style={styles.toRight}>
                             {
                             (proposalTable)?
                                 <Toggle
                                     label="Chart"
                                     labelPosition="left"
-                                    style={styles.toggle}
                                     onToggle={this.toogleProposalRender}
+                                    style={styles.toggle}
                                     toggled={proposalTable}
                                 />
                             :
                                 <Toggle
                                     label="Table"
                                     labelPosition="right"
-                                    style={styles.toggle}
                                     onToggle={this.toogleProposalRender}
+                                    style={styles.toggle}
                                     toggled={proposalTable}
                                 />
                             }

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -16,6 +16,7 @@ import * as actionCreators from '../../actions/proposal';
 
 import { ProposalTag } from '../ProposalTag';
 import { ProposalGraph } from '../ProposalGraph';
+import { ProposalTableMaterial } from '../ProposalTableMaterial';
 
 const locale = 'es';
 const dateOptions = {
@@ -136,6 +137,11 @@ export class Proposal extends Component {
           {
               proposal.prediction &&
               <ProposalGraph stacked={true} proposal={proposal} height={500} />
+          }
+
+          {
+              proposal.prediction &&
+              <ProposalTableMaterial stacked={true} proposal={proposal} height={500} />
           }
 
           {

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -23,6 +23,14 @@ const dateOptions = {
     year: 'numeric',
     month: '2-digit',
 };
+const hourOptions = {
+    day: '2-digit',
+    year: 'numeric',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+};
+
 
 const styles = {
     chip: {
@@ -82,10 +90,10 @@ export class Proposal extends Component {
         const proposal = this.state.proposal;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
-        const creationDate = new Date(proposal.creation_date).toLocaleString(locale, dateOptions);
+        const lastExecution = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
-        const subtitle = <span>{daysRange}<span><br/>Last execution <u>{creationDate}</u></span></span>;
+        const subtitle = <span>{daysRange}</span>;
 
         const Proposal = () => (
             <Card>
@@ -118,10 +126,7 @@ export class Proposal extends Component {
           }
 
               <CardText>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                Donec mattis pretium massa. Aliquam erat volutpat. Nulla facilisi.
-                Donec vulputate interdum sollicitudin. Nunc lacinia auctor quam sed pellentesque.
-                Aliquam dui mauris, mattis quis lacus id, pellentesque lobortis odio.
+                  Last execution was done at {lastExecution}
               </CardText>
 
           {

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -30,7 +30,7 @@ const validations = {
         description: 'Name of the New Proposal',
         type: 'string',
         minLength: 3,
-        maxLength: 4,
+        maxLength: 200,
         allowEmpty: false,
         required: true,
     },

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -110,12 +110,11 @@ export class ProposalDefinition extends Component {
         const proposalSummary = {
             name:this.state.name,
             aggregations:this.state.aggregationsNames,
-            "creation_date": "Fri, 11 Nov 2016 13:28:33 GMT",
+            "isNew": true,
             "days_range": [
-              "2017-09-03",
-              "2017-09-06"
+                this.state.date_start,
+                this.state.date_end,
             ],
-
         }
 
         return [
@@ -296,14 +295,12 @@ export class ProposalDefinition extends Component {
         const basicValidation = this.validateField({date_start: date_start}, "date_start", { properties: { date_start: validations.date_start} } );
 
         if (basicValidation) {
-
             if (date_start < date_limit_inf) {
                 this.setState({
                     date_start_error_text: "Start date must be higher than " + date_limit_inf.toLocaleDateString("en"),
                     date_start_validation: false,
                 });
             }
-
             this.validateDatesRange(date_start, date_end);
         }
     };

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -69,7 +69,7 @@ export class ProposalDefinition extends Component {
       this.state = {
           loading: false,
           finished: false,
-          stepIndex: 2,
+          stepIndex: 0,
           name: "",
           date_start: null,
           date_end: null,
@@ -110,11 +110,16 @@ export class ProposalDefinition extends Component {
         const proposalSummary = {
             name:this.state.name,
             aggregations:this.state.aggregationsNames,
-            "isNew": true,
-            "days_range": [
+            isNew: true,
+            days_range: [
                 this.state.date_start,
                 this.state.date_end,
             ],
+            status: {
+              "color": "pending",
+              "full": "Pending",
+              "lite": "WIP"
+            },
         }
 
         return [
@@ -140,7 +145,7 @@ export class ProposalDefinition extends Component {
                 title: "Dates",
                 content: (
                     <div>
-                        <p>Perfect! Now insert the desired <b>range of dates</b>:</p> {this.state.name}
+                        <p>Perfect! Now insert the desired <b>range of dates</b>:</p>
 
                         <DatePicker
                             floatingLabelText="Start date"

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -40,13 +40,31 @@ export class ProposalGraph extends Component {
         const height = (this.props.height)?this.props.height:500;
         const width = (this.props.width)?this.props.width:1024;
 
+        const isLite = (this.props.isLite)?this.props.isLite:false;
+
         const data=adaptProposalData(prediction);
 
         const areas = prediction.map(function(day, i) {
             return <Area key={"area"+i} type='monotone' dataKey={day.day} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
         });
 
-        return (
+
+        return (isLite)?
+        (
+            <div >
+                <ResponsiveContainer height={height} >
+                    <AreaChart  data={data}
+                        margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                        <XAxis dataKey="name"/>
+                        <YAxis/>
+                        <CartesianGrid strokeDasharray="3 3"/>
+                        {areas}
+                    </AreaChart>
+                </ResponsiveContainer>
+            </div>
+        )
+        :
+        (
             <div >
                 <ResponsiveContainer height={height} >
                 	<AreaChart  data={data}
@@ -66,6 +84,7 @@ export class ProposalGraph extends Component {
 ProposalGraph.propTypes = {
     proposal: React.PropTypes.object,
     stacked: React.PropTypes.bool,
+    isLite: React.PropTypes.bool,
     width: React.PropTypes.number,
     height: React.PropTypes.number,
 };

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -42,42 +42,44 @@ export class ProposalGraph extends Component {
 
         const isLite = (this.props.isLite)?this.props.isLite:false;
 
-        const data=adaptProposalData(prediction);
+        if (prediction) {
+            console.dir(prediction);
+            const data=adaptProposalData(prediction);
+            const areas = prediction.map(function(day, i) {
+                return <Area key={"area"+i} type='monotone' dataKey={day.day} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+            });
 
-        const areas = prediction.map(function(day, i) {
-            return <Area key={"area"+i} type='monotone' dataKey={day.day} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
-        });
-
-
-        return (isLite)?
-        (
-            <div >
-                <ResponsiveContainer height={height} >
-                    <AreaChart  data={data}
-                        margin={{top: 10, right: 30, left: 0, bottom: 0}}>
-                        <XAxis dataKey="name"/>
-                        <YAxis/>
-                        <CartesianGrid strokeDasharray="3 3"/>
-                        {areas}
-                    </AreaChart>
-                </ResponsiveContainer>
-            </div>
-        )
-        :
-        (
-            <div >
-                <ResponsiveContainer height={height} >
-                	<AreaChart  data={data}
-                        margin={{top: 10, right: 30, left: 0, bottom: 0}}>
-                        <XAxis dataKey="name"/>
-                        <YAxis/>
-                        <CartesianGrid strokeDasharray="3 3"/>
-                        <Tooltip/>
-                        {areas}
-                    </AreaChart>
-                </ResponsiveContainer>
-            </div>
-        );
+            return (isLite)?
+            (
+                <div >
+                    <ResponsiveContainer height={height} >
+                        <AreaChart  data={data}
+                            margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                            <XAxis dataKey="name"/>
+                            <YAxis/>
+                            <CartesianGrid strokeDasharray="3 3"/>
+                            {areas}
+                        </AreaChart>
+                    </ResponsiveContainer>
+                </div>
+            )
+            :
+            (
+                <div >
+                    <ResponsiveContainer height={height} >
+                    	<AreaChart  data={data}
+                            margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                            <XAxis dataKey="name"/>
+                            <YAxis/>
+                            <CartesianGrid strokeDasharray="3 3"/>
+                            <Tooltip/>
+                            {areas}
+                        </AreaChart>
+                    </ResponsiveContainer>
+                </div>
+            );
+        }
+        return null;
     }
 }
 

--- a/src/components/ProposalList/index.js
+++ b/src/components/ProposalList/index.js
@@ -86,7 +86,13 @@ export class ProposalList extends Component {
                       style={styles.gridTile}
                     >
                     <div><br/><br/><br/><br/></div>
-                    <ProposalGraph stacked={true} proposal={tile} width={ index < howManyBig ? width : width/2} height={ index < howManyBig ? height : height/2.3} />
+                    <ProposalGraph
+                        stacked={true}
+                        proposal={tile}
+                        width={ index < howManyBig ? width : width/2}
+                        height={ index < howManyBig ? height : height/2.3}
+                        isLite
+                    />
 
                     </GridTile>
               ))}

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -1,8 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import {ResponsiveContainer} from 'recharts';
-
 import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
@@ -37,20 +35,19 @@ export class ProposalTableMaterial extends Component {
 
     render() {
         const prediction = this.props.proposal.prediction;
-        const stacked = (this.props.stacked)?"1":null;
+        const type = (this.props.type)?this.props.type:null;
 
         const height = (this.props.height)?this.props.height:500;
         const width = (this.props.width)?this.props.width:1024;
 
-        const isLite = (this.props.isLite)?this.props.isLite:false;
-
+        //Adapt proposal data (transpose data to days and columns dimension)
         const data=adaptProposalData(prediction);
 
         //Prepare headers
         const headers = prediction.map(function(day, i) {
             return (
                 <TableRowColumn key={"header"+i} stroke={colors[i]} fill={colors[i]}>
-                    {day.day}
+                    <b>{day.day}</b>
                 </TableRowColumn>
             )
         });
@@ -79,21 +76,13 @@ export class ProposalTableMaterial extends Component {
             );
         }
 
-        return (isLite)?
-        (
-            <div >
-                <ResponsiveContainer height={height} >
-                </ResponsiveContainer>
-            </div>
-        )
-        :
-        (
+        return (
             <div >
                 <Table>
                     <TableHeader displaySelectAll={false}>
                         <TableRow key="headersRow">
                             <TableRowColumn key={"headerHour"}>
-                                Hour
+                                <b>Hour</b>
                             </TableRowColumn>
 
                             {headers}

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -1,0 +1,117 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import {ResponsiveContainer} from 'recharts';
+
+import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
+
+//import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
+
+import {adaptProposalData} from '../../utils/graph';
+
+const styles = {
+    dialog: {
+        width: '80%',
+        maxWidth: 'none',
+    },
+    graphContainer: {
+        maxWidth: '500px',
+        maxHeight: '200px',
+    }
+
+};
+
+const colors = [
+    '#db4939',
+    '#f29913',
+    '#3c8cba',
+    '#00a658'
+]
+
+export class ProposalTableMaterial extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+        };
+    }
+
+    render() {
+        const prediction = this.props.proposal.prediction;
+        const stacked = (this.props.stacked)?"1":null;
+
+        const height = (this.props.height)?this.props.height:500;
+        const width = (this.props.width)?this.props.width:1024;
+
+        const isLite = (this.props.isLite)?this.props.isLite:false;
+
+        const data=adaptProposalData(prediction);
+
+        //Prepare headers
+        const headers = prediction.map(function(day, i) {
+            return (
+                <TableRowColumn key={"header"+i} stroke={colors[i]} fill={colors[i]}>
+                    {day.day}
+                </TableRowColumn>
+            )
+        });
+
+        //Prepare rows and cells
+        let rows=[];
+        for (var i=0; i<data.length; i++) {
+            let cells=[];
+            cells.push(
+                <TableRowColumn key={"Column"+i}>
+                    {data[i].name}
+                </TableRowColumn>
+            );
+            for (var j=0; j<prediction.length; j++) {
+                cells.push(
+                    <TableRowColumn key={"Column"+i+j}>
+                        {data[i][prediction[j].day]}
+                    </TableRowColumn>
+                );
+            }
+
+            rows.push (
+                <TableRow key={"tableRow"+i}>
+                    {cells}
+                </TableRow>
+            );
+        }
+
+        return (isLite)?
+        (
+            <div >
+                <ResponsiveContainer height={height} >
+                </ResponsiveContainer>
+            </div>
+        )
+        :
+        (
+            <div >
+                <Table>
+                    <TableHeader displaySelectAll={false}>
+                        <TableRow key="headersRow">
+                            <TableRowColumn key={"headerHour"}>
+                                Hour
+                            </TableRowColumn>
+
+                            {headers}
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody displayRowCheckbox={false}>
+                        {rows}
+                    </TableBody>
+                </Table>
+            </div>
+        );
+    }
+}
+
+ProposalTableMaterial.propTypes = {
+    proposal: React.PropTypes.object.isRequired,
+    type: React.PropTypes.bool,
+    isLite: React.PropTypes.bool,
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
+};

--- a/src/containers/App/styles/app.scss
+++ b/src/containers/App/styles/app.scss
@@ -11,3 +11,11 @@
   }
 
 }
+
+
+@media (min-width: 992px) {
+    :global(#aggregationsList) {
+      align-items: center;
+      justify-content: center;
+    }
+}

--- a/src/containers/App/styles/app.scss
+++ b/src/containers/App/styles/app.scss
@@ -12,6 +12,12 @@
 
 }
 
+@media (max-width: 991px) {
+    :global(#aggregationsList) {
+      align-items: flex-start !important;
+      justify-content: flex-start !important;
+    }
+}
 
 @media (min-width: 992px) {
     :global(#aggregationsList) {

--- a/src/containers/App/styles/app.scss
+++ b/src/containers/App/styles/app.scss
@@ -12,16 +12,30 @@
 
 }
 
+//Fixing aggregationsList of <Proposal>
 @media (max-width: 991px) {
     :global(#aggregationsList) {
       align-items: flex-start !important;
       justify-content: flex-start !important;
     }
 }
-
 @media (min-width: 992px) {
     :global(#aggregationsList) {
       align-items: center;
       justify-content: center;
+    }
+}
+
+//Fixing tooglePicture of <Proposal>
+@media (max-width: 1199px) {
+    :global(#togglePicture) {
+      align-items: flex-start !important;
+      justify-content: flex-start !important;
+    }
+}
+@media (min-width: 992px) {
+    :global(#togglePicture #toogleElement) {
+        margin-left: 3px;
+        margin-right: 3px;
     }
 }


### PR DESCRIPTION
### \<ProposalTableMaterial>

Provide the new component\ <ProposalTableMaterial> that prints a Proposal in a materialized table.

#### Provided changes
* \<ProposalTableMaterial> component
* \<Proposal> now 
  * integrates \<ProposalTableMaterial>
  * integrates a toggle to select the way to render a Proposal (Table / Chart)
  * render is reviewed and audited to provide a responsive experience through all size devices

Fix #25 