### PR TITLE
Bug logout clear state

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -18,12 +18,11 @@ const appReducer = combineReducers({
 
 const rootReducer = (state, action) => {
   if (action.type === 'LOGOUT_USER') {
-    //state = undefined;
-    state.auth = undefined;
-    state.data = undefined;
-    state.proposals = undefined;
-    state.proposal = undefined;
-    state.profile = undefined;
+    // Clear all states except routing
+    Object.keys(state).forEach(function(oneState,index) {
+        if (oneState != "routing")
+            state[oneState] = undefined;
+    });
   }
   return appReducer(state, action);
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,7 +6,7 @@ import profile  from './profile'
 import proposal  from './proposal'
 import proposals  from './proposals'
 
-const rootReducer = combineReducers({
+const appReducer = combineReducers({
     routing: routerReducer,
     auth,
     data,
@@ -14,5 +14,9 @@ const rootReducer = combineReducers({
     proposal,
     profile,
 });
+
+const rootReducer = (state, action) => {
+  return appReducer(state, action)
+}
 
 export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import data  from './data'
 import profile  from './profile'
 import proposal  from './proposal'
 import proposals  from './proposals'
+import { LOGOUT_USER } from '../constants/index'
 
 const appReducer = combineReducers({
     routing: routerReducer,
@@ -16,7 +17,15 @@ const appReducer = combineReducers({
 });
 
 const rootReducer = (state, action) => {
-  return appReducer(state, action)
+  if (action.type === 'LOGOUT_USER') {
+    //state = undefined;
+    state.auth = undefined;
+    state.data = undefined;
+    state.proposals = undefined;
+    state.proposal = undefined;
+    state.profile = undefined;
+  }
+  return appReducer(state, action);
 }
 
 export default rootReducer;


### PR DESCRIPTION
The storage remains with data until the request is refreshed, as expected in a normal Redux flow.

The goal of this PR is that the storage has been evolved to integrate some middleware that handles and inject global state changes depending on the type.

In this particular case, if a LOGOUT_USER action is received, all the tunned storage states (except routing) will be cleared.

Fix #35 