### PR TITLE
BUG while rerunning proposal 

### DIFF
--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -151,7 +151,7 @@ export class Proposal extends Component {
 
     render() {
         const readOnly = (this.props.readOnly)?this.props.readOnly:false;
-        const proposal = this.state.proposal;
+        const proposal = this.props.proposal;
 
         const proposalTable = this.state.proposalTable;
 


### PR DESCRIPTION
So far Proposal data is not updated.

With this the "re-runned" version of the Proposal is updated to the current view.

The BUG was related to use the saved state instead of the received prop at <Proposal>.

Fix #46