### PR TITLE
Cleaning views

### DIFF
--- a/src/components/ProfileView.js
+++ b/src/components/ProfileView.js
@@ -42,23 +42,19 @@ export default class ProfileView extends React.Component {
     render() {
         return (
             <div>
-                {!this.props.loaded
-                    ?
-                    this.props.error?
-                        <div>
-                            <h1>There was an error</h1>
-                            {this.props.errorMessage.message}
-                        </div>
-                        :
-                        <div>
-                            <h1>Loading Profile {this.props.userName}...</h1>
-                        </div>
-                    :
+                {
+                    (!this.props.loaded) ?
 
-                    <div>
-                        <h1>Your profile</h1>
-                        <UserProfile onUpdate={(changed_data) => this.updateData(changed_data)}/>
-                    </div>
+                        this.props.error &&
+                            <div>
+                                <h1>There was an error</h1>
+                                {this.props.errorMessage.message}
+                            </div>
+                    :
+                        <div>
+                            <h1>Your profile</h1>
+                            <UserProfile onUpdate={(changed_data) => this.updateData(changed_data)}/>
+                        </div>
                 }
 
                 {debug(this.props.data)}

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -145,7 +145,7 @@ export class Proposal extends Component {
 
     refreshProposal = (event, proposalID) => {
         this.setState({
-            message_text: "Refreshing proposal.",
+            message_text: "Refreshing proposal",
         });
         const token = this.props.token;
         this.props.fetchProposal(token, proposalID);
@@ -153,7 +153,7 @@ export class Proposal extends Component {
 
     reRunProposal = (event, proposalID) => {
         this.setState({
-            message_text: "Forcing a reprocessing of the proposal.",
+            message_text: "Forcing a reprocessing of the proposal",
         });
         const token = this.props.token;
         this.props.runProposal(token, proposalID);
@@ -161,7 +161,7 @@ export class Proposal extends Component {
 
     duplicateProposal = (event, proposalID) => {
         this.setState({
-            message_text: "Duplicating current proposal.",
+            message_text: "Duplicating current proposal",
         });
         const token = this.props.token;
         this.props.duplicateProposal(token, proposalID);
@@ -169,7 +169,7 @@ export class Proposal extends Component {
 
     deleteProposal = (event, proposalID) => {
         this.setState({
-            message_text: "Deleting current proposal.",
+            message_text: "Deleting current proposal",
         });
         const token = this.props.token;
         this.props.deleteProposal(token, proposalID);

--- a/src/components/ProposalNewView.js
+++ b/src/components/ProposalNewView.js
@@ -9,7 +9,7 @@ import { ProposalDefinition } from './ProposalDefinition';
 
 function mapStateToProps(state) {
     return {
-        data: state.proposal,
+        aggregations: state.proposal.aggregations_list,
         token: state.auth.token,
     };
 }
@@ -22,11 +22,6 @@ function mapDispatchToProps(dispatch) {
 export default class ProfileView extends React.Component {
     componentWillMount() {
         this.fetchAggregations();
-    }
-
-    updateData(data) {
-        const token = this.props.token;
-        this.props.updateProfile(token, data);
     }
 
     fetchAggregations() {
@@ -42,14 +37,14 @@ export default class ProfileView extends React.Component {
 
                     <h1>New proposal</h1>
 
-                    {!this.props.data.loaded
+                    {!this.props.aggregations
                         ? <h1>Loading New proposal...</h1>
                         :
-                        <ProposalDefinition aggregationsList={this.props.data.aggregations_list}/>
+                        <ProposalDefinition aggregationsList={this.props.aggregations}/>
                     }
                 </div>
 
-                {debug(this.props.data)}
+                {debug(this.props.aggregations)}
             </div>
         );
     }

--- a/src/components/ProposalNewView.js
+++ b/src/components/ProposalNewView.js
@@ -20,7 +20,7 @@ function mapDispatchToProps(dispatch) {
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class ProfileView extends React.Component {
-    componentDidMount() {
+    componentWillMount() {
         this.fetchAggregations();
     }
 

--- a/src/components/ProposalNewView.js
+++ b/src/components/ProposalNewView.js
@@ -37,9 +37,7 @@ export default class ProfileView extends React.Component {
 
                     <h1>New proposal</h1>
 
-                    {!this.props.aggregations
-                        ? <h1>Loading New proposal...</h1>
-                        :
+                    {this.props.aggregations &&
                         <ProposalDefinition aggregationsList={this.props.aggregations}/>
                     }
                 </div>

--- a/src/components/ProposalView.js
+++ b/src/components/ProposalView.js
@@ -47,9 +47,7 @@ export default class ProposalView extends React.Component {
 
             return (
                 <div>
-                    {!this.props.loaded
-                        ? <h1>Loading Proposal {proposalId}...</h1>
-                        :
+                    {this.props.loaded &&
                         <div>
                             <Proposal
                                 proposal={proposal}

--- a/src/components/ProposalsView.js
+++ b/src/components/ProposalsView.js
@@ -56,7 +56,7 @@ export default class ProposalsView extends React.Component {
     refreshData() {
         this.fetchData();
         this.setState({
-            message_text: "Refreshing data",
+            message_text: "Refreshing proposals list",
         });
     }
 

--- a/src/components/ProposalsView.js
+++ b/src/components/ProposalsView.js
@@ -67,9 +67,7 @@ export default class ProposalsView extends React.Component {
     render() {
         return (
             <div>
-                {!this.props.loaded
-                    ? <h1>Loading Proposals...</h1>
-                    :
+                {this.props.loaded &&
                     <div>
                         <Notification message={this.state.message_text}/>
 


### PR DESCRIPTION
Some cleaning actions to reach more speed at loading views and avoid render "waiting" messages.

Also fix #77 ensuring that New Proposal view is render once the Aggregations data is received.
