### PR TITLE
Proposal actions confirmation & Proposal animations

### DIFF
--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -239,6 +239,7 @@ export class Proposal extends Component {
 
 
 
+
     duplicateProposalQuestion = (event, proposalID) => {
         event.preventDefault();
         this.confirmation.confirmation_open = true;
@@ -275,13 +276,47 @@ export class Proposal extends Component {
         this.props.duplicateProposal(token, proposalID);
     };
 
-    deleteProposal = (event, proposalID) => {
+
+
+
+    deleteProposalQuestion = (event, proposalID) => {
+        event.preventDefault();
+        this.confirmation.confirmation_open = true;
+
+        const actionsButtons = [
+          <FlatButton
+            label="Cancel"
+            primary={true}
+            onTouchTap={this.handleCloseConfirmation}
+          />,
+          <FlatButton
+            label="Submit"
+            primary={true}
+            keyboardFocused={true}
+            onTouchTap={() => this.deleteProposal(proposalID)}
+          />,
+        ];
+
+        this.confirmation.title = "Delete current Proposal";
+        this.confirmation.text = <div><p>The Proposal will deleted. This process can't be undone...</p><p>Are you sure about to <b>delete this Proposal</b>?</p></div>;
+        this.confirmation.actionsButtons = actionsButtons;
+
+        this.setState({
+            message_text: null,
+            confirmation_open: true,
+        });
+    };
+
+    deleteProposal = (proposalID) => {
         this.setState({
             message_text: "Deleting current proposal",
         });
         const token = this.props.token;
         this.props.deleteProposal(token, proposalID);
     };
+
+
+
 
     handleConfirmation = (what, message, text) => {
         this.next = what;
@@ -322,7 +357,7 @@ export class Proposal extends Component {
         const refreshProposal=this.refreshProposalQuestion;
         const reRunProposal=this.reRunProposalQuestion;
         const duplicateProposal=this.duplicateProposalQuestion;
-        const deleteProposal=this.deleteProposal;
+        const deleteProposal=this.deleteProposalQuestion;
 
         const actionsButtons = [
           <FlatButton

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -536,8 +536,10 @@ x
                   open={this.state.confirmation_open}
                   title={this.confirmation.title}
                   actions={this.confirmation.actionsButtons}
+                  modal={false}
+                  onRequestClose={this.handleCloseConfirmation}
                 >
-                {this.confirmation.text}
+                    {this.confirmation.text}
                 </Dialog>
 
                 <Notification

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -176,8 +176,8 @@ export class Proposal extends Component {
           />,
         ];
 
-        this.confirmation.title = "Are you sure about to refresh the Proposal?";
-        this.confirmation.text = "The Proposal will be refetched from the API.";
+        this.confirmation.title = "Refresh current proposal";
+        this.confirmation.text = <div><p>The Proposal will be refreshed fetching the last changes at DB. Unsaved changes will be discarted.</p><p>Are you sure about to <b>refresh this Proposal</b>?</p></div>;
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
@@ -185,7 +185,7 @@ export class Proposal extends Component {
             confirmation_open: true,
         });
     };
-
+x
     refreshProposal = (proposalID) => {
         this.setState({
             message_text: "Refreshing proposal",
@@ -218,8 +218,8 @@ export class Proposal extends Component {
           />,
         ];
 
-        this.confirmation.title = "Are you sure about to (re)Run the Proposal?";
-        this.confirmation.text = <div><p>The Proposal will be reprocessed from the API.</p><p>It can take a few seconds...</p></div>;
+        this.confirmation.title = "Reprocess current Proposal";
+        this.confirmation.text = <div><p>The Proposal will be reprocessed using the last data on DB. It can take a few seconds...</p><p>Are you sure about to <b>reprocess this Proposal</b>?</p></div>;
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
@@ -258,8 +258,8 @@ export class Proposal extends Component {
           />,
         ];
 
-        this.confirmation.title = "Duplicate a Proposal";
-        this.confirmation.text = <div><p>The Proposal will duplicated. It can take a few seconds to finalize...</p><p>Are you sure about to duplicate this Proposal?</p></div>;
+        this.confirmation.title = "Duplicate current Proposal";
+        this.confirmation.text = <div><p>The Proposal will be duplicated. The consumptions will not be reprocessed, if needed "Run" the new Proposal once it's cloned.</p><p>Are you sure about to <b>duplicate this Proposal</b>?</p></div>;
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
@@ -271,6 +271,7 @@ export class Proposal extends Component {
     duplicateProposal = (proposalID) => {
         this.setState({
             message_text: "Duplicating current proposal",
+            confirmation_open: false,
         });
         const token = this.props.token;
         this.props.duplicateProposal(token, proposalID);
@@ -298,7 +299,7 @@ export class Proposal extends Component {
         ];
 
         this.confirmation.title = "Delete current Proposal";
-        this.confirmation.text = <div><p>The Proposal will deleted. This process can't be undone...</p><p>Are you sure about to <b>delete this Proposal</b>?</p></div>;
+        this.confirmation.text = <div><p>The Proposal will be deleted. This process can't be undone...</p><p>Are you sure about to <b>delete this Proposal</b>?</p></div>;
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
@@ -310,6 +311,7 @@ export class Proposal extends Component {
     deleteProposal = (proposalID) => {
         this.setState({
             message_text: "Deleting current proposal",
+            confirmation_open: false,
         });
         const token = this.props.token;
         this.props.deleteProposal(token, proposalID);

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -477,7 +477,7 @@ x
                   (proposalTable)?
                       <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
                       :
-                      <ProposalGraph stacked={true} data={data} components={components} height={500} />
+                      <ProposalGraph stacked={true} data={data} components={components} height={500} animated={false} />
                   :null
 
         // The resulting Proposal element

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -198,14 +198,48 @@ export class Proposal extends Component {
 
     };
 
-    reRunProposal = (event, proposalID) => {
-        this.handleOpenConfirmation();
+
+
+
+    reRunProposalQuestion = (event, proposalID) => {
+        event.preventDefault();
+        this.confirmation.confirmation_open = true;
+
+        const actionsButtons = [
+          <FlatButton
+            label="Cancel"
+            primary={true}
+            onTouchTap={this.handleCloseConfirmation}
+          />,
+          <FlatButton
+            label="Submit"
+            primary={true}
+            keyboardFocused={true}
+            onTouchTap={() => this.reRunProposal(proposalID)}
+          />,
+        ];
+
+        this.confirmation.title = "Are you sure about to (re)Run the Proposal?";
+        this.confirmation.text = <div><p>The Proposal will be reprocessed from the API.</p><p>It can take a few seconds...</p></div>;
+        this.confirmation.actionsButtons = actionsButtons;
+
+        this.setState({
+            message_text: null,
+            confirmation_open: true,
+        });
+    };
+
+    reRunProposal = (proposalID) => {
         this.setState({
             message_text: "Forcing a reprocessing of the proposal",
+            confirmation_open: false,
         });
         const token = this.props.token;
-        //this.props.runProposal(token, proposalID);
+        this.props.runProposal(token, proposalID);
     };
+
+
+
 
     duplicateProposal = (event, proposalID) => {
         this.setState({
@@ -260,7 +294,7 @@ export class Proposal extends Component {
         const aggregations = this.state.aggregations;
 
         const refreshProposal=this.refreshProposalQuestion;
-        const reRunProposal=this.reRunProposal;
+        const reRunProposal=this.reRunProposalQuestion;
         const duplicateProposal=this.duplicateProposal;
         const deleteProposal=this.deleteProposal;
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -525,11 +525,6 @@ x
             </Card>
         );
 
-        console.log("this.state.message_text");
-        console.log(this.state.message_text);
-
-
-
         return (
             <div>
                 <Dialog

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -119,7 +119,7 @@ export class Proposal extends Component {
             message_text: null,
             confirmation_text: null,
             confirmation_open: false,
-            animateChart: false,
+            animateChart: true,
         };
         props.aggregations[0].selected = true;
     }
@@ -132,7 +132,7 @@ export class Proposal extends Component {
         this.setState({
             proposalTable: status,
             message_text: null,
-            animateChart: true,
+            animateChart: false,
         });
     };
 
@@ -149,7 +149,7 @@ export class Proposal extends Component {
         this.setState({
             aggregationSelected: agg.id,
             message_text: null,
-            animateChart: true,
+            animateChart: false,
         });
     };
 
@@ -278,7 +278,7 @@ export class Proposal extends Component {
 
     duplicateProposal = (proposalID) => {
         this.setState({
-            animateChart: true,
+            animateChart: false,
             message_text: "Duplicating current proposal",
             confirmation_open: false,
         });
@@ -320,7 +320,7 @@ export class Proposal extends Component {
 
     deleteProposal = (proposalID) => {
         this.setState({
-            animateChart: true,
+            animateChart: false,
             message_text: "Deleting current proposal",
             confirmation_open: false,
         });

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -119,6 +119,7 @@ export class Proposal extends Component {
             message_text: null,
             confirmation_text: null,
             confirmation_open: false,
+            animateChart: false,
         };
         props.aggregations[0].selected = true;
     }
@@ -131,6 +132,7 @@ export class Proposal extends Component {
         this.setState({
             proposalTable: status,
             message_text: null,
+            animateChart: true,
         });
     };
 
@@ -147,6 +149,7 @@ export class Proposal extends Component {
         this.setState({
             aggregationSelected: agg.id,
             message_text: null,
+            animateChart: true,
         });
     };
 
@@ -181,13 +184,15 @@ export class Proposal extends Component {
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
+            animateChart: false,
             message_text: null,
             confirmation_open: true,
         });
     };
-x
+
     refreshProposal = (proposalID) => {
         this.setState({
+            animateChart: true,
             message_text: "Refreshing proposal",
             confirmation_open: false,
         });
@@ -223,6 +228,7 @@ x
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
+            animateChart: false,
             message_text: null,
             confirmation_open: true,
         });
@@ -230,6 +236,7 @@ x
 
     reRunProposal = (proposalID) => {
         this.setState({
+            animateChart: true,
             message_text: "Forcing a reprocessing of the proposal",
             confirmation_open: false,
         });
@@ -263,6 +270,7 @@ x
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
+            animateChart: false,
             message_text: null,
             confirmation_open: true,
         });
@@ -270,6 +278,7 @@ x
 
     duplicateProposal = (proposalID) => {
         this.setState({
+            animateChart: true,
             message_text: "Duplicating current proposal",
             confirmation_open: false,
         });
@@ -303,6 +312,7 @@ x
         this.confirmation.actionsButtons = actionsButtons;
 
         this.setState({
+            animateChart: false,
             message_text: null,
             confirmation_open: true,
         });
@@ -310,6 +320,7 @@ x
 
     deleteProposal = (proposalID) => {
         this.setState({
+            animateChart: true,
             message_text: "Deleting current proposal",
             confirmation_open: false,
         });
@@ -477,7 +488,7 @@ x
                   (proposalTable)?
                       <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
                       :
-                      <ProposalGraph stacked={true} data={data} components={components} height={500} animated={false} />
+                      <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.state.animateChart} />
                   :null
 
         // The resulting Proposal element

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -162,8 +162,6 @@ export class Proposal extends Component {
         event.preventDefault();
         this.confirmation.confirmation_open = true;
 
-        const token = this.props.token;
-
         const actionsButtons = [
           <FlatButton
             label="Cancel"
@@ -174,7 +172,7 @@ export class Proposal extends Component {
             label="Submit"
             primary={true}
             keyboardFocused={true}
-            onTouchTap={() => this.refreshProposal(token, proposalID)}
+            onTouchTap={() => this.refreshProposal(proposalID)}
           />,
         ];
 
@@ -188,12 +186,13 @@ export class Proposal extends Component {
         });
     };
 
-    refreshProposal = (token, proposalID) => {
+    refreshProposal = (proposalID) => {
         this.setState({
             message_text: "Refreshing proposal",
             confirmation_open: false,
         });
 
+        const token = this.props.token;
         this.props.fetchProposal(token, proposalID);
 
     };

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -239,8 +239,35 @@ export class Proposal extends Component {
 
 
 
+    duplicateProposalQuestion = (event, proposalID) => {
+        event.preventDefault();
+        this.confirmation.confirmation_open = true;
 
-    duplicateProposal = (event, proposalID) => {
+        const actionsButtons = [
+          <FlatButton
+            label="Cancel"
+            primary={true}
+            onTouchTap={this.handleCloseConfirmation}
+          />,
+          <FlatButton
+            label="Submit"
+            primary={true}
+            keyboardFocused={true}
+            onTouchTap={() => this.duplicateProposal(proposalID)}
+          />,
+        ];
+
+        this.confirmation.title = "Duplicate a Proposal";
+        this.confirmation.text = <div><p>The Proposal will duplicated. It can take a few seconds to finalize...</p><p>Are you sure about to duplicate this Proposal?</p></div>;
+        this.confirmation.actionsButtons = actionsButtons;
+
+        this.setState({
+            message_text: null,
+            confirmation_open: true,
+        });
+    };
+
+    duplicateProposal = (proposalID) => {
         this.setState({
             message_text: "Duplicating current proposal",
         });
@@ -294,7 +321,7 @@ export class Proposal extends Component {
 
         const refreshProposal=this.refreshProposalQuestion;
         const reRunProposal=this.reRunProposalQuestion;
-        const duplicateProposal=this.duplicateProposal;
+        const duplicateProposal=this.duplicateProposalQuestion;
         const deleteProposal=this.deleteProposal;
 
         const actionsButtons = [

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -38,10 +38,11 @@ export class ProposalGraph extends Component {
         const width = (this.props.width)?this.props.width:1024;
 
         const isLite = (this.props.isLite)?this.props.isLite:false;
+        const isAnimated = (this.props.animated)?this.props.animated:false;
 
         if (data && components) {
             const areas = Object.keys(components).map(function(component, i) {
-                return <Area isAnimationActive={false} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+                return <Area isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
             });
 
             /* Aggregations selector
@@ -91,6 +92,7 @@ ProposalGraph.propTypes = {
     components: React.PropTypes.object.isRequired,
     stacked: React.PropTypes.bool,
     isLite: React.PropTypes.bool,
+    animated: React.PropTypes.bool,
     width: React.PropTypes.number,
     height: React.PropTypes.number,
 };

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -41,7 +41,7 @@ export class ProposalGraph extends Component {
 
         if (data && components) {
             const areas = Object.keys(components).map(function(component, i) {
-                return <Area key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+                return <Area isAnimationActive={false} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
             });
 
             /* Aggregations selector
@@ -68,7 +68,7 @@ export class ProposalGraph extends Component {
             (
                 <div >
                     <ResponsiveContainer height={height} >
-                    	<AreaChart  data={data}
+                    	<AreaChart data={data}
                             margin={{top: 10, right: 30, left: 0, bottom: 0}}>
                             <XAxis dataKey="name"/>
                             <YAxis/>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {debug} from './debug';
 export const DEBUG = (debug)?debug:false;
 


### PR DESCRIPTION
#### Provided changes
* A Dialog is triggered when a Proposal action is asked (refresh, run, duplicate, delete)
  * If the user Confirm it, 
      * the action is performed
      * the Notification is creted
* The BUG that animates the Chart at every new Proposal state is solved! Animation chart is **disabled** for:
  * Chart type toggle
  * Selected Aggregation change
, and **activated** for:
  * Load Proposal //the first time that the graph is created
  * Refresh Proposal //action Refresh
  * ReRUN Prorposal //action Run

#### Fixed issues
* Fix #80 :: Bug at updating Proposal charts for each new state 
* Fix #67 :: Confirmation dialog for each Proposal action