### PR TITLE
WSGI integration and API proxification

### DIFF
--- a/conf/frontend.conf
+++ b/conf/frontend.conf
@@ -1,0 +1,38 @@
+server {
+    listen 80 default_server;
+
+    # include snippets/snakeoil.conf;
+    #root /var/www/html;
+    index index.html index.htm;
+
+    server_name $HOST_NAME;
+
+    access_log /var/log/orakwlum/frontend.access.log;
+    error_log /var/log/orakwlum/frontend.error.log;
+
+    proxy_buffers 16 64k;
+    proxy_buffer_size 128k;
+
+    location / {
+        proxy_pass  http://localhost:3000;
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_redirect off;
+
+        proxy_read_timeout          10;
+        proxy_connect_timeout       10;
+        proxy_send_timeout          10;
+        send_timeout                10;
+
+        proxy_set_header            Host     $host;
+        proxy_set_header            X-Real-IP       $remote_addr;
+        proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header            X-Forwarded-Proto https;
+    }
+
+    location /api { try_files $uri @orakwlum-api; }
+
+    location @orakwlum-api {
+        include uwsgi_params;
+        uwsgi_pass unix:/tmp/orakwlum-api.sock;
+    }
+}

--- a/server.js
+++ b/server.js
@@ -29,10 +29,6 @@ app.use(require('morgan')('short'));
 
 app.use(express.static('public'));
 
-app.all(/^\/api\/(.*)/, (req, res) => {
-    proxy.web(req, res, { target: 'http://localhost:5000' });
-});
-
 app.get(/.*/, (req, res) => {
     res.sendFile(path.join(__dirname, '/index.html'));
 });


### PR DESCRIPTION
#### It provides

* nginx default vhost configuration
  * proxify / -> node stream
  * proxify /api -> API uwsgi server

With it, NodeJS **avoid** to proxify /api -> API flask server

Fix #88 :: Add configuration

Related to https://github.com/gisce/oraKWlum-api-pub/issues/77