### PR TITLE
BUG Proposals list Refresh

### DIFF
--- a/src/components/ProposalList/index.js
+++ b/src/components/ProposalList/index.js
@@ -55,10 +55,8 @@ export class ProposalList extends Component {
 
         this.state = {
             open: false,
-            proposals: props.proposals,
             title: props.title,
             path: props.path + "/",
-            aggregations: props.aggregations,
             aggregationSelected: props.aggregations[defaultAggregation].id,
         };
 
@@ -67,7 +65,7 @@ export class ProposalList extends Component {
 
     changeProposalAggregation = (event, agg) => {
         //initialize selection of all elements
-        const aggregations = this.state.aggregations;
+        const aggregations = this.props.aggregations;
         Object.keys(aggregations).map( function(agg, i) {
             aggregations[agg].selected = false;
         });
@@ -97,7 +95,7 @@ export class ProposalList extends Component {
         const aggregationsStyle = (withPicture)?styles.aggregations:styles.aggregationsRight;
 
         const changeProposalAggregation=this.changeProposalAggregation;
-        const aggregations = this.state.aggregations;
+        const aggregations = this.props.aggregations;
         const aggregationSelected = this.state.aggregationSelected;
 
         const proposalAggregations = (
@@ -125,7 +123,6 @@ export class ProposalList extends Component {
 
         // Last Proposals (the first bug, the other ones 2 per row)
         const lastProposals =data_received.map((tile, index) => {
-            console.log("arribo");
             if (tile.prediction) {
                 const predictionAdapted=adaptProposalData(tile.prediction);
                 const current = predictionAdapted[aggregationSelected];
@@ -160,8 +157,6 @@ export class ProposalList extends Component {
                 );
             }
             else {
-                console.log("else");
-
                 return (
                     <GridTile
                         key={tile.id}

--- a/src/components/ProposalList/index.js
+++ b/src/components/ProposalList/index.js
@@ -82,7 +82,7 @@ export class ProposalList extends Component {
     };
 
     render() {
-        const data_received = this.state.proposals;
+        const data_received = this.props.proposals;
 
         const width=1024;
         const height=300;

--- a/src/components/ProposalsView.js
+++ b/src/components/ProposalsView.js
@@ -67,31 +67,32 @@ export default class ProposalsView extends React.Component {
     render() {
         return (
             <div>
-		<Notification message={this.state.message_text}/>
-		<ContentHeader
-		    title="Proposals List"
-		    addButton={true}
-		    addClickMethod={() => this.addProposal()}
+        		<Notification message={this.state.message_text}/>
+        		<ContentHeader
+        		    title="Proposals List"
+        		    addButton={true}
+        		    addClickMethod={() => this.addProposal()}
 
-		    refreshButton={true}
-		    refreshClickMethod={() => this.refreshData()}
+        		    refreshButton={true}
+        		    refreshClickMethod={() => this.refreshData()}
                 />
-                {this.props.loaded?
-                    <div>
-                        <ProposalList
-                            title="Last proposals"
-                            proposals={this.props.data.data}
-                            aggregations={this.props.allAggregations}
-                            path={this.props.location.pathname}
-                        />
+            {
+                this.props.loaded?
+                <div>
+                    <ProposalList
+                        title="Last proposals"
+                        proposals={this.props.data.data}
+                        aggregations={this.props.allAggregations}
+                        path={this.props.location.pathname}
+                    />
 
-                    </div>
-		:
-                    <div>
-                        <h3>There are no Proposals to show</h3>
-                    </div>
-                }
-            {debug(this.props)}
+                </div>
+            :
+                <div>
+                    <h3>There are no Proposals to show</h3>
+                </div>
+            }
+                {debug(this.props.data.data)}
             </div>
         );
     }

--- a/src/constants/debug.js
+++ b/src/constants/debug.js
@@ -1,2 +1,1 @@
-export const debug = false;
-
+export const debug = true;


### PR DESCRIPTION
Exist a BUG at the Proposals list view related with the refresh process.

The new data is received but not populated to the Proposals List component.

It solves it, enforcing to use the PROPS data instead of the saved STATE data.

Same solution is applied for the "aggregations list".

Fix #91 :: BUG Proposals list refresh