### PR TITLE
BUG Error at Showing an empty Proposal

### DIFF
--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -89,7 +89,7 @@ export class ProposalGraph extends Component {
 
 ProposalGraph.propTypes = {
     data: React.PropTypes.array,
-    components: React.PropTypes.object.isRequired,
+    components: React.PropTypes.object,
     stacked: React.PropTypes.bool,
     isLite: React.PropTypes.bool,
     animated: React.PropTypes.bool,

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -88,7 +88,7 @@ export class ProposalGraph extends Component {
 }
 
 ProposalGraph.propTypes = {
-    data: React.PropTypes.array.isRequired,
+    data: React.PropTypes.array,
     components: React.PropTypes.object.isRequired,
     stacked: React.PropTypes.bool,
     isLite: React.PropTypes.bool,


### PR DESCRIPTION
If data or components are empty is already handled inside the component.

There are cases, like "Create a new Proposal" that render and displays
a non calculed (without data/components) Proposal.

Fix #100 :: BUG Internal error at showing an empty Proposal