### PR TITLE
Gravatar integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
       "webpack-dev-server": "^1.16.2",
       "webpack-hot-middleware": "^2.15.0",
       "webpack-merge": "^2.3.1",
-      "yargs": "^6.6.0"
+      "yargs": "^6.6.0",
+      "blueimp-md5": "latest"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orakwlum-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -18,6 +18,7 @@ import CancelIcon from 'material-ui/svg-icons/navigation/cancel';
 import SaveIcon from 'material-ui/svg-icons/content/save';
 import KeyIcon from 'material-ui/svg-icons/communication/vpn-key';
 
+import { MD5 } from '../../utils/misc'
 
 function handleRequestDelete() {
     alert('Treure TAG.');
@@ -159,6 +160,11 @@ export class UserProfile extends Component {
 
         const message_open = this.state.message_open;
 
+        const emailHash = MD5(profile.email);
+
+        //Load gravatar img or default from github
+        const image = "https://www.gravatar.com/avatar/"+emailHash+"?d=https://raw.githubusercontent.com/gisce/oraKWlum-frontend/master/www/public/images/user.jpg";
+
         const UserProfile = () => (
 
             <div>
@@ -178,7 +184,7 @@ export class UserProfile extends Component {
                     <CardHeader
                       title={profile.email}
                       subtitle={profile.roles}
-                      avatar={profile.image}
+                      avatar={image}
                     />
                     <CardTitle
                       title="Personal data"

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,5 +1,8 @@
 /* eslint max-len: 0, no-param-reassign: 0 */
 
+//import {md5} from 'blueimp-md5/js/md5';
+var md5 = require("../../node_modules/blueimp-md5/js/md5.js");
+
 export function createConstants(...constants) {
     return constants.reduce((acc, constant) => {
         acc[constant] = constant;
@@ -18,7 +21,6 @@ export function createReducer(initialState, reducerMap) {
     };
 }
 
-
 export function parseJSON(response) {
     return response.data;
 }
@@ -26,4 +28,8 @@ export function parseJSON(response) {
 export function validateEmail(email) {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(email);
+}
+
+export function MD5(text){
+    return md5(text);
 }


### PR DESCRIPTION
### Integrate Gravatar image

If don't exist any profile for the current logged user, fallback to the default image serverd from Github.

#### Provided changes
* Gravatar integration functionality

#### Detailed changes
* \<UserProfile> now 
  * computes the md5 hash of the Profile email
  * try to load the avatar image from Gravatar using the hash
    * if not exist any profile, assign the default image
* Added dependency "blueimp-md5" to reach a MD5 hasher lib
* created MD5(text) method at /utils/misc.js

Fix #118 :: Gravatar integration
