### PR TITLE
Workaround for BUG for the last hour of a Proposal

### DIFF
--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -18,7 +18,7 @@ export function adaptProposalData(proposalData, hour=25) {
         for (var i=0; i<hour; i++)
             result[aggID]['result'][i]={name: i+":00"}
     }
-    
+
     proposalData.result.map(function(aggregation, i) {
         const prediction = aggregation.result.sum;
         const aggregationTitle = aggregation.aggregation;
@@ -37,12 +37,16 @@ export function adaptProposalData(proposalData, hour=25) {
 
             //Hour is ever fixed (and must be extracted from the aggregations name)
             const hourDetail = "" + hourComponentsArray[0];
-            const hourExact = parseInt(hourDetail.slice(11,13));
+            let hourExact = parseInt(hourDetail.slice(11,13));
 
 
             //Aggregations can be dynamic (one, two, ...) but used as the other dimension of the array (x=hour, y=aggregations ), ie. x=8:00, y="F1:50" / x=8:00 y="F5D:30"
             //If there are just one aggregation (hour), create the y="*"
             const hourAggregation = (hourComponentsArray.length == 1)?["*"]:hourComponentsArray.slice(1, hourComponentsArray.length);
+
+            // If current hour exits and have a value, (for the 00 of start day and 00 of end day)
+            if (result[aggregationID]['result'][hourExact][hourAggregation] != undefined)
+                hourExact = 24;
 
             result[aggregationID]['result'][hourExact][hourAggregation] = 0 + prediction[hour];
 


### PR DESCRIPTION
Fix #125, this applies to the last hour of the proposal. If overrides by
default to the fist hour of the proposal, both pointing to 00:00 but to
diff days.

The workaround moves to the end the last hour of the proposal.

Concretely, if current hour exits and have a value, set current hour to 25.

That's not the ending solution, but provides a quick fix.

The final solution will be something similar to group measures in a list
of days, and paint iterating the sorted list of days.

Fix #125 