### PR TITLE
Proposals Bar Chart

### DIFF
--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -163,7 +163,7 @@ export class ProposalGraph extends Component {
               const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} label={{maringBottom: 10}}/>;
               const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
 
-              const xaxis = <XAxis dataKey="name"/>;
+              const xaxis = <XAxis dataKey="name" label={"Hour"}/>;
               const yaxis = <YAxis label={unit}/>;
 
               return (isLite)?
@@ -188,7 +188,7 @@ export class ProposalGraph extends Component {
                       <ResponsiveContainer height={height} >
                       	<ComposedChart
                             data={data}
-                            margin={{top: 20, right: 30, left: 0, bottom: 0}}
+                            margin={{top: 20, right: 50, left: 0, bottom: 0}}
                         >
                             {xaxis}
                             {yaxis}

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -1,7 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import {AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer} from 'recharts';
+import {AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer} from 'recharts';
+
+
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
@@ -43,10 +45,6 @@ export class ProposalGraph extends Component {
         const isAnimated = (this.props.animated)?this.props.animated:false;
 
         if (data && components) {
-            const areas = Object.keys(components).map(function(component, i) {
-                return <Area isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
-            });
-
             /* Aggregations selector
             const areas = prediction.map(function(day, i) {
                 return <Area key={"area"+i} type='monotone' dataKey={day.day} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
@@ -55,6 +53,10 @@ export class ProposalGraph extends Component {
 
 
             if (isAreaChart) {
+              const areas = Object.keys(components).map(function(component, i) {
+                  return <Area isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+              });
+
 
               return (isLite)?
               (
@@ -87,17 +89,22 @@ export class ProposalGraph extends Component {
               );
             }
             else {
+              const bars = Object.keys(components).map(function(component, i) {
+                  return <Bar isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+              });
+
+
               return (isLite)?
               (
                   <div >
                       <ResponsiveContainer height={height} >
-                          <AreaChart  data={data}
+                          <BarChart  data={data}
                               margin={{top: 10, right: 30, left: 0, bottom: 0}}>
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
-                              {areas}
-                          </AreaChart>
+                              {bars}
+                          </BarChart>
                       </ResponsiveContainer>
                   </div>
               )
@@ -105,14 +112,14 @@ export class ProposalGraph extends Component {
               (
                   <div >
                       <ResponsiveContainer height={height} >
-                      	<AreaChart data={data}
+                      	<BarChart data={data}
                               margin={{top: 10, right: 30, left: 0, bottom: 0}}>
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip/>
-                              {areas}
-                          </AreaChart>
+                              {bars}
+                          </BarChart>
                       </ResponsiveContainer>
                   </div>
               );

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -20,19 +20,14 @@ const styles = {
         maxWidth: '500px',
         maxHeight: '200px',
     },
-    legend: {
-      top: 40,
-      right: 20,
-      backgroundColor: '#f5f5f5',
-      border: '1px solid #d5d5d5',
-      borderRadius: 3,
-      lineHeight: '40px',
-    },
     tooltip: {
       backgroundColor: "white",
       border: "1px solid grey",
       paddingLeft: 15,
       paddingRight: 15,
+    },
+    legend: {
+      width: "100%",
     },
 };
 
@@ -59,7 +54,7 @@ const CustomTooltip  = React.createClass({
                 color: "white",
                 padding: 3,
                 borderRadius: 5,
-                paddingLeft: 10,
+                paddingLeft: 0,
                 paddingRight: 10,
               };
               const name = (component.name == "total")?component.name.toUpperCase():component.name;
@@ -155,9 +150,8 @@ export class ProposalGraph extends Component {
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
-                              <Tooltip/>
-                              <Legend width={100} wrapperStyle={styles.legend}/>
                               {bars}
+                              <Line type='monotone' dataKey='total' stroke='#000000'/>
                           </BarChart>
                       </ResponsiveContainer>
                   </div>
@@ -173,6 +167,7 @@ export class ProposalGraph extends Component {
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip content={<CustomTooltip/>}/>
                               {bars}
+                              <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>
                               <Line type='monotone' dataKey='total' stroke='#000000'/>
                           </ComposedChart>
                       </ResponsiveContainer>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import {AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend} from 'recharts';
+import {ComposedChart, AreaChart, Area, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend} from 'recharts';
 
 
 
@@ -21,8 +21,8 @@ const styles = {
         maxHeight: '200px',
     },
     legend: {
-      //top: 40,
-      //right: 20,
+      top: 40,
+      right: 20,
       backgroundColor: '#f5f5f5',
       border: '1px solid #d5d5d5',
       borderRadius: 3,
@@ -36,6 +36,8 @@ export class ProposalGraph extends Component {
         this.state = {
         };
     }
+
+    // toDo review why the hour 0 stills appears
 
     render() {
         const data = this.props.data;
@@ -100,16 +102,17 @@ export class ProposalGraph extends Component {
                   return <Bar isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
               });
 
-
               return (isLite)?
               (
                   <div >
                       <ResponsiveContainer height={height} >
-                          <BarChart  data={data}
+                        <BarChart data={data}
                               margin={{top: 10, right: 30, left: 0, bottom: 0}}>
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
+                              <Tooltip/>
+                              <Legend width={100} wrapperStyle={styles.legend}/>
                               {bars}
                           </BarChart>
                       </ResponsiveContainer>
@@ -119,15 +122,15 @@ export class ProposalGraph extends Component {
               (
                   <div >
                       <ResponsiveContainer height={height} >
-                      	<BarChart data={data}
+                      	<ComposedChart data={data}
                               margin={{top: 10, right: 30, left: 0, bottom: 0}}>
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip/>
-                              <Legend width={100} wrapperStyle={styles.legend}/>
                               {bars}
-                          </BarChart>
+                              <Line type='monotone' dataKey='total' stroke='#ff7300'/>
+                          </ComposedChart>
                       </ResponsiveContainer>
                   </div>
               );

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -65,10 +65,10 @@ const CustomTooltip  = React.createClass({
               if (component.name == "total") {
                   componentStyle.backgroundColor = "white",
                   componentStyle.color = "black";
-                  name = <strong>{component.name.toUpperCase()}</strong>;
+                  name = component.name.toUpperCase();
               }
 
-              return <p key={"tooltip" + i} style={componentStyle}>{name}: {component.value} {component.unit}</p>
+              return <p key={"tooltip" + i} style={componentStyle}><strong>{name}</strong>: {component.value} {component.unit}</p>
             })
           }
         </div>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -162,6 +162,8 @@ export class ProposalGraph extends Component {
 
               const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} label={{maringBottom: 10}}/>;
               const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
+
+              const xaxis = <XAxis dataKey="name"/>;
               const yaxis = <YAxis label={unit}/>;
 
               return (isLite)?
@@ -171,11 +173,11 @@ export class ProposalGraph extends Component {
                         <BarChart data={data}
                             margin={{top: 20, right: 30, left: 0, bottom: 0}}
                         >
-                              <XAxis dataKey="name"/>
-                              {yaxis}
-                              <CartesianGrid strokeDasharray="3 3"/>
-                              {bars}
-                              {line}
+                            {xaxis}
+                            {yaxis}
+                            <CartesianGrid strokeDasharray="3 3"/>
+                            {bars}
+                            {line}
                           </BarChart>
                       </ResponsiveContainer>
                   </div>
@@ -188,13 +190,13 @@ export class ProposalGraph extends Component {
                             data={data}
                             margin={{top: 20, right: 30, left: 0, bottom: 0}}
                         >
-                              <XAxis dataKey="name"/>
-                              {yaxis}
-                              <CartesianGrid strokeDasharray="3 3"/>
-                              <Tooltip content={<CustomTooltip/>}/>
-                              {bars}
-                              {line}
-                              {legend}
+                            {xaxis}
+                            {yaxis}
+                            <CartesianGrid strokeDasharray="3 3"/>
+                            <Tooltip content={<CustomTooltip/>}/>
+                            {bars}
+                            {line}
+                            {legend}
                           </ComposedChart>
                       </ResponsiveContainer>
                   </div>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -27,8 +27,52 @@ const styles = {
       border: '1px solid #d5d5d5',
       borderRadius: 3,
       lineHeight: '40px',
-    }
+    },
+    tooltip: {
+      backgroundColor: "white",
+      border: "1px solid grey",
+      paddingLeft: 15,
+      paddingRight: 15,
+    },
 };
+
+const CustomTooltip  = React.createClass({
+  propTypes: {
+    type: PropTypes.string,
+    payload: PropTypes.array,
+    label: PropTypes.any,
+  },
+
+  render() {
+    const { active } = this.props;
+
+    if (active) {
+      const { payload, label } = this.props;
+      return (
+        <div style={styles.tooltip} className="custom-tooltip">
+          <h4 className="desc"><strong>Hour #{label}</strong></h4>
+          {
+            Object.keys(payload).map(function(comp, i) {
+              const component = payload[i];
+              const componentStyle = {
+                backgroundColor: component.color,
+                color: "white",
+                padding: 3,
+                borderRadius: 5,
+                paddingLeft: 10,
+                paddingRight: 10,
+              };
+              const name = (component.name == "total")?component.name.toUpperCase():component.name;
+              return <p key={"tooltip" + i} style={componentStyle}>{name}: {component.value}</p>
+            })
+          }
+        </div>
+      );
+    }
+
+    return null;
+  }
+});
 
 export class ProposalGraph extends Component {
     constructor(props) {
@@ -127,7 +171,7 @@ export class ProposalGraph extends Component {
                               <XAxis dataKey="name"/>
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
-                              <Tooltip/>
+                              <Tooltip content={<CustomTooltip/>}/>
                               {bars}
                               <Line type='monotone' dataKey='total' stroke='#000000'/>
                           </ComposedChart>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import {AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer} from 'recharts';
+import {AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend} from 'recharts';
 
 
 
@@ -19,8 +19,15 @@ const styles = {
     graphContainer: {
         maxWidth: '500px',
         maxHeight: '200px',
+    },
+    legend: {
+      //top: 40,
+      //right: 20,
+      backgroundColor: '#f5f5f5',
+      border: '1px solid #d5d5d5',
+      borderRadius: 3,
+      lineHeight: '40px',
     }
-
 };
 
 export class ProposalGraph extends Component {
@@ -118,6 +125,7 @@ export class ProposalGraph extends Component {
                               <YAxis/>
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip/>
+                              <Legend width={100} wrapperStyle={styles.legend}/>
                               {bars}
                           </BarChart>
                       </ResponsiveContainer>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -49,7 +49,9 @@ const CustomTooltip  = React.createClass({
           {
             Object.keys(payload).map(function(comp, i) {
               const component = payload[i];
-              const componentStyle = {
+
+              let {name} = component;
+              let componentStyle = {
                 backgroundColor: component.color,
                 color: "white",
                 padding: 5,
@@ -57,8 +59,15 @@ const CustomTooltip  = React.createClass({
                 paddingLeft: 7,
                 paddingRight: 7,
                 textAlign: "left",
+                fontSize: 12,
               };
-              const name = (component.name == "total")?component.name.toUpperCase():component.name;
+
+              if (component.name == "total") {
+                  componentStyle.backgroundColor = "white",
+                  componentStyle.color = "black";
+                  name = <strong>{component.name.toUpperCase()}</strong>;
+              }
+
               return <p key={"tooltip" + i} style={componentStyle}>{name}: {component.value} {component.unit}</p>
             })
           }

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -162,16 +162,17 @@ export class ProposalGraph extends Component {
 
               const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} label={{maringBottom: 10}}/>;
               const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
+              const yaxis = <YAxis label={unit}/>;
 
               return (isLite)?
               (
                   <div >
                       <ResponsiveContainer height={height} >
                         <BarChart data={data}
-                            margin={{top: 10, right: 30, left: 0, bottom: 0}}
+                            margin={{top: 20, right: 30, left: 0, bottom: 0}}
                         >
                               <XAxis dataKey="name"/>
-                              <YAxis label={unit}/>
+                              {yaxis}
                               <CartesianGrid strokeDasharray="3 3"/>
                               {bars}
                               {line}
@@ -188,7 +189,7 @@ export class ProposalGraph extends Component {
                             margin={{top: 20, right: 30, left: 0, bottom: 0}}
                         >
                               <XAxis dataKey="name"/>
-                              <YAxis label={unit}/>
+                              {yaxis}
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip content={<CustomTooltip/>}/>
                               {bars}

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -38,6 +38,8 @@ export class ProposalGraph extends Component {
         const width = (this.props.width)?this.props.width:1024;
 
         const isLite = (this.props.isLite)?this.props.isLite:false;
+        const isAreaChart = (this.props.areaChart)?this.props.areaChart:false;
+
         const isAnimated = (this.props.animated)?this.props.animated:false;
 
         if (data && components) {
@@ -51,35 +53,72 @@ export class ProposalGraph extends Component {
             });
             //*/
 
-            return (isLite)?
-            (
-                <div >
-                    <ResponsiveContainer height={height} >
-                        <AreaChart  data={data}
-                            margin={{top: 10, right: 30, left: 0, bottom: 0}}>
-                            <XAxis dataKey="name"/>
-                            <YAxis/>
-                            <CartesianGrid strokeDasharray="3 3"/>
-                            {areas}
-                        </AreaChart>
-                    </ResponsiveContainer>
-                </div>
-            )
-            :
-            (
-                <div >
-                    <ResponsiveContainer height={height} >
-                    	<AreaChart data={data}
-                            margin={{top: 10, right: 30, left: 0, bottom: 0}}>
-                            <XAxis dataKey="name"/>
-                            <YAxis/>
-                            <CartesianGrid strokeDasharray="3 3"/>
-                            <Tooltip/>
-                            {areas}
-                        </AreaChart>
-                    </ResponsiveContainer>
-                </div>
-            );
+
+            if (isAreaChart) {
+
+              return (isLite)?
+              (
+                  <div >
+                      <ResponsiveContainer height={height} >
+                          <AreaChart  data={data}
+                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                              <XAxis dataKey="name"/>
+                              <YAxis/>
+                              <CartesianGrid strokeDasharray="3 3"/>
+                              {areas}
+                          </AreaChart>
+                      </ResponsiveContainer>
+                  </div>
+              )
+              :
+              (
+                  <div >
+                      <ResponsiveContainer height={height} >
+                      	<AreaChart data={data}
+                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                              <XAxis dataKey="name"/>
+                              <YAxis/>
+                              <CartesianGrid strokeDasharray="3 3"/>
+                              <Tooltip/>
+                              {areas}
+                          </AreaChart>
+                      </ResponsiveContainer>
+                  </div>
+              );
+            }
+            else {
+              return (isLite)?
+              (
+                  <div >
+                      <ResponsiveContainer height={height} >
+                          <AreaChart  data={data}
+                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                              <XAxis dataKey="name"/>
+                              <YAxis/>
+                              <CartesianGrid strokeDasharray="3 3"/>
+                              {areas}
+                          </AreaChart>
+                      </ResponsiveContainer>
+                  </div>
+              )
+              :
+              (
+                  <div >
+                      <ResponsiveContainer height={height} >
+                      	<AreaChart data={data}
+                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                              <XAxis dataKey="name"/>
+                              <YAxis/>
+                              <CartesianGrid strokeDasharray="3 3"/>
+                              <Tooltip/>
+                              {areas}
+                          </AreaChart>
+                      </ResponsiveContainer>
+                  </div>
+              );
+            }
+
+
         }
         //*/
 
@@ -92,6 +131,7 @@ ProposalGraph.propTypes = {
     components: React.PropTypes.object,
     stacked: React.PropTypes.bool,
     isLite: React.PropTypes.bool,
+    areaChart: React.PropTypes.bool,
     animated: React.PropTypes.bool,
     width: React.PropTypes.number,
     height: React.PropTypes.number,

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -160,7 +160,7 @@ export class ProposalGraph extends Component {
                           />
               });
 
-              const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} label={{maringBottom: 10}}/>;
+              const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} />;
               const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
 
               const xaxis = <XAxis dataKey="name" label={"Hour"}/>;

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -173,20 +173,26 @@ export class ProposalGraph extends Component {
               const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
 
               const xaxis = <XAxis dataKey="name" label={"Hour"}/>;
+              const xaxisLite = <XAxis dataKey="name"/>;
+
               const yaxis = <YAxis label={unit}/>;
+              const yaxisLite = <YAxis/>;
+
+              const grid = <CartesianGrid strokeDasharray="3 3"/>;
+
+              const tooltip = <Tooltip content={<CustomTooltip/>}/>;
 
               return (isLite)?
               (
                   <div >
                       <ResponsiveContainer height={height} >
                         <BarChart data={data}
-                            margin={{top: 20, right: 30, left: 0, bottom: 0}}
+                          margin={{top: 20, right: 20, left: 0, bottom: 0}}
                         >
-                            {xaxis}
-                            {yaxis}
-                            <CartesianGrid strokeDasharray="3 3"/>
+                            {xaxisLite}
+                            {yaxisLite}
+                            {grid}
                             {bars}
-                            {line}
                           </BarChart>
                       </ResponsiveContainer>
                   </div>
@@ -201,11 +207,11 @@ export class ProposalGraph extends Component {
                         >
                             {xaxis}
                             {yaxis}
-                            <CartesianGrid strokeDasharray="3 3"/>
-                            <Tooltip content={<CustomTooltip/>}/>
+                            {grid}
                             {bars}
                             {line}
                             {legend}
+                            {tooltip}
                           </ComposedChart>
                       </ResponsiveContainer>
                   </div>

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -129,14 +129,12 @@ export class ProposalGraph extends Component {
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip/>
                               {bars}
-                              <Line type='monotone' dataKey='total' stroke='#ff7300'/>
+                              <Line type='monotone' dataKey='total' stroke='#000000'/>
                           </ComposedChart>
                       </ResponsiveContainer>
                   </div>
               );
             }
-
-
         }
         //*/
 

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -52,13 +52,14 @@ const CustomTooltip  = React.createClass({
               const componentStyle = {
                 backgroundColor: component.color,
                 color: "white",
-                padding: 3,
+                padding: 5,
                 borderRadius: 5,
-                paddingLeft: 0,
-                paddingRight: 10,
+                paddingLeft: 7,
+                paddingRight: 7,
+                textAlign: "left",
               };
               const name = (component.name == "total")?component.name.toUpperCase():component.name;
-              return <p key={"tooltip" + i} style={componentStyle}>{name}: {component.value}</p>
+              return <p key={"tooltip" + i} style={componentStyle}>{name}: {component.value} {component.unit}</p>
             })
           }
         </div>
@@ -99,12 +100,21 @@ export class ProposalGraph extends Component {
             });
             //*/
 
+            const unit = "kW";
 
             if (isAreaChart) {
               const areas = Object.keys(components).map(function(component, i) {
-                  return <Area isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+                  return <Area
+                            unit={unit}
+                            isAnimationActive={isAnimated}
+                            key={"area"+i}
+                            type='monotone'
+                            dataKey={component}
+                            stackId={stacked}
+                            stroke={colors[i]}
+                            fill={colors[i]}
+                          />
               });
-
 
               return (isLite)?
               (
@@ -138,20 +148,33 @@ export class ProposalGraph extends Component {
             }
             else {
               const bars = Object.keys(components).map(function(component, i) {
-                  return <Bar isAnimationActive={isAnimated} key={"area"+i} type='monotone' dataKey={component} stackId={stacked} stroke={colors[i]} fill={colors[i]} />
+                  return <Bar
+                            unit={unit}
+                            isAnimationActive={isAnimated}
+                            key={"area"+i}
+                            type='monotone'
+                            dataKey={component}
+                            stackId={stacked}
+                            stroke={colors[i]}
+                            fill={colors[i]}
+                          />
               });
+
+              const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} label={{maringBottom: 10}}/>;
+              const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
 
               return (isLite)?
               (
                   <div >
                       <ResponsiveContainer height={height} >
                         <BarChart data={data}
-                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                            margin={{top: 10, right: 30, left: 0, bottom: 0}}
+                        >
                               <XAxis dataKey="name"/>
-                              <YAxis/>
+                              <YAxis label={unit}/>
                               <CartesianGrid strokeDasharray="3 3"/>
                               {bars}
-                              <Line type='monotone' dataKey='total' stroke='#000000'/>
+                              {line}
                           </BarChart>
                       </ResponsiveContainer>
                   </div>
@@ -160,22 +183,23 @@ export class ProposalGraph extends Component {
               (
                   <div >
                       <ResponsiveContainer height={height} >
-                      	<ComposedChart data={data}
-                              margin={{top: 10, right: 30, left: 0, bottom: 0}}>
+                      	<ComposedChart
+                            data={data}
+                            margin={{top: 20, right: 30, left: 0, bottom: 0}}
+                        >
                               <XAxis dataKey="name"/>
-                              <YAxis/>
+                              <YAxis label={unit}/>
                               <CartesianGrid strokeDasharray="3 3"/>
                               <Tooltip content={<CustomTooltip/>}/>
                               {bars}
-                              <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>
-                              <Line type='monotone' dataKey='total' stroke='#000000'/>
+                              {line}
+                              {legend}
                           </ComposedChart>
                       </ResponsiveContainer>
                   </div>
               );
             }
         }
-        //*/
 
         return null;
     }

--- a/src/constants/debug.js
+++ b/src/constants/debug.js
@@ -1,1 +1,1 @@
-export const debug = true;
+export const debug = false;

--- a/src/constants/debug.js
+++ b/src/constants/debug.js
@@ -1,1 +1,1 @@
-export const debug = false;
+export const debug = true;

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -15,8 +15,10 @@ export function adaptProposalData(proposalData, hour=24) {
         result[aggID]['components']={};
 
         //initialize hours
-        for (var i=0; i<hour; i++)
+        for (var i=0; i<hour; i++) {
             result[aggID]['result'][i]={name: i+1}
+            result[aggID]['result'][i]={total: 0}
+        }
     }
 
     proposalData.result.map(function(aggregation, i) {
@@ -48,6 +50,7 @@ export function adaptProposalData(proposalData, hour=24) {
                 hourExact = 24;
 
             result[aggregationID]['result'][hourExact-1][hourAggregation] = 0 + prediction[hour];
+            result[aggregationID]['result'][hourExact-1]["total"] += 0 + prediction[hour];
 
             //append aggregation value if so far not exist
             const componentName = "" + hourAggregation.toString();

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -17,7 +17,7 @@ export function adaptProposalData(proposalData, hour=24) {
 
         //initialize hours
         for (var i=0; i<hour; i++) {
-            result[aggID]['result'][i]={total: 0, name: i};
+            result[aggID]['result'][i]={total: 0, name: i+1};
         }
     }
 

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -1,6 +1,7 @@
 
 
 export function adaptProposalData(proposalData, hour=24) {
+  console.log("entro");
     let result={};
     const aggregationNum = proposalData.result.length;
 
@@ -16,8 +17,7 @@ export function adaptProposalData(proposalData, hour=24) {
 
         //initialize hours
         for (var i=0; i<hour; i++) {
-            result[aggID]['result'][i]={name: i+1}
-            result[aggID]['result'][i]={total: 0}
+            result[aggID]['result'][i]={total: 0, name: i};
         }
     }
 

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -1,6 +1,6 @@
 
 
-export function adaptProposalData(proposalData, hour=25) {
+export function adaptProposalData(proposalData, hour=24) {
     let result={};
     const aggregationNum = proposalData.result.length;
 
@@ -47,14 +47,16 @@ export function adaptProposalData(proposalData, hour=25) {
             if (hourExact == 0)
                 hourExact = 24;
 
-            result[aggregationID]['result'][hourExact][hourAggregation] = 0 + prediction[hour];
+            result[aggregationID]['result'][hourExact-1][hourAggregation] = 0 + prediction[hour];
 
             //append aggregation value if so far not exist
             const componentName = "" + hourAggregation.toString();
             result[aggregationID]['components'][componentName] = componentName;
         })
-
     });
+
+
+    console.log(result);
 
     return result;
 }

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -16,7 +16,7 @@ export function adaptProposalData(proposalData, hour=24) {
 
         //initialize hours
         for (var i=0; i<hour; i++)
-            result[aggID]['result'][i]={name: i}
+            result[aggID]['result'][i]={name: i+1}
     }
 
     proposalData.result.map(function(aggregation, i) {
@@ -54,9 +54,6 @@ export function adaptProposalData(proposalData, hour=24) {
             result[aggregationID]['components'][componentName] = componentName;
         })
     });
-
-
-    console.log(result);
 
     return result;
 }


### PR DESCRIPTION
It provides a way to render a Proposal using a Bar Chart.

So far, there's just an Area chart.

### Provided changes

* \<ProposalGraph> 

  * now accept the new bool parameter "areaChart" to change the type of the Chart. By default it render using a Bar Chart.

  * Bar chart include a line that marks the total tendency for each hour

  * have an improved tooltip that focuses on to explain the current component easily

  * render a new **legend** that contributes to understand the color association 

  * show the label of each axis ("kw" / "hour")

Fix #128 :: Stacked bar chart for Proposal detail

