### PR TITLE
Release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orakwlum-frontend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/actions/proposal.js
+++ b/src/actions/proposal.js
@@ -205,6 +205,27 @@ export function createProposal(token, proposal) {
 }
 
 
+export function createHistoricProposal(token, proposal) {
+    return (dispatch) => {
+        dispatch(createProposalRequest());
+        data_create_api_resource(token, "historic/", proposal)
+            .then(parseJSON)
+            .then(response => {
+                if (response.result.status == "ok") {
+                    dispatch(fetchProposal(token, response.result.id));
+                    dispatch(redirectToRoute("/proposals/"+response.result.id));
+                }
+                else {
+                    console.log("error creating proposal " + proposal);
+                }
+            })
+            .catch(error => {
+                if (error.status === 401) {
+                    dispatch(logoutAndRedirect(error));
+                }
+            });
+    };
+}
 
 
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -153,7 +153,7 @@ export class Header extends Component {
                                 <MenuItem
                                     onClick={() => this.dispatchRoute('/historics/new')}
                                     leftIcon={<HistoryIcon/>}
-                                    primaryText="History"
+                                    primaryText="Historics"
                                 />
                                 <MenuItem
                                     onClick={() => this.dispatchRoute('/buys')}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -151,15 +151,14 @@ export class Header extends Component {
                                     primaryText="Proposals"
                                 />
                                 <MenuItem
+                                    onClick={() => this.dispatchRoute('/historics/new')}
+                                    leftIcon={<HistoryIcon/>}
+                                    primaryText="History"
+                                />
+                                <MenuItem
                                     onClick={() => this.dispatchRoute('/buys')}
                                     leftIcon={<EuroIcon/>}
                                     primaryText="Buys"
-                                    disabled
-                                />
-                                <MenuItem
-                                    onClick={() => this.dispatchRoute('/history')}
-                                    leftIcon={<HistoryIcon/>}
-                                    primaryText="History"
                                     disabled
                                 />
 

--- a/src/components/HistoryNewView.js
+++ b/src/components/HistoryNewView.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { debug } from '../utils/debug';
+
+import * as actionCreators from '../actions/proposal';
+
+import { ProposalDefinition } from './ProposalDefinition';
+
+function mapStateToProps(state) {
+    return {
+        aggregations: state.proposal.aggregations_list,
+        token: state.auth.token,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return bindActionCreators(actionCreators, dispatch);
+}
+
+@connect(mapStateToProps, mapDispatchToProps)
+export default class HistoryNewView extends React.Component {
+    componentWillMount() {
+        this.fetchAggregations();
+    }
+
+    fetchAggregations() {
+        const token = this.props.token;
+        this.props.fetchAggregations(token);
+    }
+
+    render() {
+        return (
+            <div>
+
+                <div>
+
+                    <h1>New historic</h1>
+
+                    {this.props.aggregations &&
+                        <ProposalDefinition aggregationsList={this.props.aggregations}/>
+                    }
+                </div>
+
+                {debug(this.props.aggregations)}
+            </div>
+        );
+    }
+}
+
+HistoryNewView.propTypes = {
+    data: React.PropTypes.any,
+    token: React.PropTypes.string,
+};

--- a/src/components/HistoryNewView.js
+++ b/src/components/HistoryNewView.js
@@ -38,7 +38,7 @@ export default class HistoryNewView extends React.Component {
                     <h1>New historic</h1>
 
                     {this.props.aggregations &&
-                        <ProposalDefinition aggregationsList={this.props.aggregations}/>
+                        <ProposalDefinition aggregationsList={this.props.aggregations} type="historic"/>
                     }
                 </div>
 

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -18,10 +18,11 @@ const styles = {
     },
     paperDepth: 4,
     fixedSize: {
+        paddingTop:10,
         height: 80,
         textAlign: 'center',
         overflow:'auto',
-    }
+    },
 };
 
 
@@ -37,19 +38,10 @@ export class Indicator extends Component {
         const value_asInt = parseInt(value);
 
         const is_percentage = (this.props.percentage)?this.props.percentage:false;
-
         const total = (this.props.total)?parseInt(this.props.total):0;
 
+        const icon = (this.props.icon)?this.props.icon:false;
 
-/*        <CircularProgress
-          mode="determinate"
-          value={parseInt(value)}
-          max={total}
-          size={80}
-          thickness={7}
-        />
-
-    */
         const visual_indicator = (is_percentage) && (total>=0) ?
             (
                 <div style={styles.fixedSize}>
@@ -66,6 +58,7 @@ export class Indicator extends Component {
             :
             (
                 <div style={styles.fixedSize}>
+                    {icon}
                 </div>
             )
 

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -54,9 +54,23 @@ export class Indicator extends Component {
 
         const which_size = (is_small)? styles.smallSize : styles.normalSize;
 
+        const which_color = (this.props.color)? this.props.color : false;
+
+        const style_background_color = (which_color)?
+            {
+                backgroundColor: which_color,
+                color: 'black',
+            }
+        :
+            {
+            }
+        ;
+
+
         const paper_style = Object.assign({
             height: which_size.height,
             width: which_size.width,
+            backgroundColor: which_color,
         }, styles.paper);
 
         const {title, value} = this.props;
@@ -71,13 +85,15 @@ export class Indicator extends Component {
             (
                 <div style={styles.fixedSize}>
                     <CircularProgress
-                              mode="determinate"
-                              value={value_asInt}
-                              max={total}
-                              size={50}
-                              thickness={7}
+                        mode="determinate"
+                        value={value_asInt}
+                        max={total}
+                        size={50}
+                        thickness={7}
+                        color= {style_background_color.color}
                     />
-                <br/>{((value_asInt/total)*100).toFixed(1)}%
+                <br/>
+                {((value_asInt/total)*100).toFixed(1)}%
                 </div>
             )
             :
@@ -88,6 +104,9 @@ export class Indicator extends Component {
             )
 
             ;
+
+
+
 
 
         return (
@@ -109,4 +128,5 @@ Indicator.propTypes = {
     percentage: React.PropTypes.bool,
     total: React.PropTypes.number,
     small: React.PropTypes.bool,
+    color: React.PropTypes.string,
 };

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -77,7 +77,7 @@ export class Indicator extends Component {
                               size={50}
                               thickness={7}
                     />
-                    <br/>{(value_asInt/total)*100}%
+                <br/>{((value_asInt/total)*100).toFixed(1)}%
                 </div>
             )
             :

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -1,0 +1,62 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import Paper from 'material-ui/Paper';
+import CircularProgress from 'material-ui/CircularProgress';
+
+//import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
+
+import {colors} from '../../constants';
+
+const styles = {
+    paper: {
+        height: 150,
+        width: 150,
+        margin: 20,
+        textAlign: 'center',
+        display: 'inline-block',
+    },
+    paperDepth: 4,
+};
+
+
+export class Indicator extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+        };
+    }
+
+    render() {
+        const {title, value} = this.props;
+
+        const is_percentage = (this.props.percentage)?this.props.percentage:false;
+
+        const total = (this.props.total)?parseInt(this.props.total):0;
+
+        const visual_indicator = (is_percentage) && (total>=0) &&
+            (
+                <div>{total}</div>
+            );
+
+
+        return (
+            <Paper key={"invoice_"+title} style={styles.paper} zDepth={styles.paperDepth}>
+                <div className="inner">
+                  <h3>{title}</h3>
+                  <p>{value}</p>
+                </div>
+                <div className="icon">
+                  <i className="ion ion-bag"></i>
+                </div>
+            </Paper>
+        );
+    }
+}
+
+Indicator.propTypes = {
+    title: React.PropTypes.string.isRequired,
+    value: React.PropTypes.string.isRequired,
+    percentage: React.PropTypes.bool,
+    total: React.PropTypes.number,
+};

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -33,7 +33,7 @@ const styles = {
     },
     smallSize: {
         height: 200,
-        width: 100,
+        width: 120,
     },
     kingSize: {
         height: 300,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -10,13 +10,18 @@ import {colors} from '../../constants';
 
 const styles = {
     paper: {
-        height: 150,
-        width: 150,
+        height: 200,
+        width: 200,
         margin: 20,
         textAlign: 'center',
         display: 'inline-block',
     },
     paperDepth: 4,
+    fixedSize: {
+        height: 80,
+        textAlign: 'center',
+        overflow:'auto',
+    }
 };
 
 
@@ -29,26 +34,49 @@ export class Indicator extends Component {
 
     render() {
         const {title, value} = this.props;
+        const value_asInt = parseInt(value);
 
         const is_percentage = (this.props.percentage)?this.props.percentage:false;
 
         const total = (this.props.total)?parseInt(this.props.total):0;
 
-        const visual_indicator = (is_percentage) && (total>=0) &&
+
+/*        <CircularProgress
+          mode="determinate"
+          value={parseInt(value)}
+          max={total}
+          size={80}
+          thickness={7}
+        />
+
+    */
+        const visual_indicator = (is_percentage) && (total>=0) ?
             (
-                <div>{total}</div>
-            );
+                <div style={styles.fixedSize}>
+                    <CircularProgress
+                              mode="determinate"
+                              value={value_asInt}
+                              max={total}
+                              size={50}
+                              thickness={7}
+                    />
+                    <br/>{(value_asInt/total)*100}%
+                </div>
+            )
+            :
+            (
+                <div style={styles.fixedSize}>
+                </div>
+            )
+
+            ;
 
 
         return (
             <Paper key={"invoice_"+title} style={styles.paper} zDepth={styles.paperDepth}>
-                <div className="inner">
-                  <h3>{title}</h3>
-                  <p>{value}</p>
-                </div>
-                <div className="icon">
-                  <i className="ion ion-bag"></i>
-                </div>
+                <h3>{title}</h3>
+                <p>{value}</p>
+                {visual_indicator}
             </Paper>
         );
     }
@@ -56,7 +84,10 @@ export class Indicator extends Component {
 
 Indicator.propTypes = {
     title: React.PropTypes.string.isRequired,
-    value: React.PropTypes.string.isRequired,
+    value: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number,
+    ]).isRequired,
     percentage: React.PropTypes.bool,
     total: React.PropTypes.number,
 };

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -56,10 +56,12 @@ export class Indicator extends Component {
 
         const which_color = (this.props.color)? this.props.color : false;
 
-        const style_background_color = (which_color)?
+
+
+        const style_color = (which_color)?
             {
                 backgroundColor: which_color,
-                color: 'black',
+                color: (which_color == "#000000")?'white':'black',
             }
         :
             {
@@ -90,10 +92,10 @@ export class Indicator extends Component {
                         max={total}
                         size={50}
                         thickness={7}
-                        color= {style_background_color.color}
+                        color= {style_color.color}
                     />
-                <br/>
-                {((value_asInt/total)*100).toFixed(1)}%
+                    <br/>
+                    {((value_asInt/total)*100).toFixed(1)}%
                 </div>
             )
             :
@@ -105,15 +107,13 @@ export class Indicator extends Component {
 
             ;
 
-
-
-
-
         return (
             <Paper key={"invoice_"+title} style={paper_style} zDepth={styles.paperDepth}>
-                <h3 style={styles.header}>{title}</h3>
-                <span style={styles.value}>{value}</span>
-                {visual_indicator}
+                <div style={{ color: style_color.color }}>
+                    <h3 style={styles.header}>{title}</h3>
+                    <span style={styles.value}>{value}</span>
+                    {visual_indicator}
+                </div>
             </Paper>
         );
     }

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -10,8 +10,6 @@ import {colors} from '../../constants';
 
 const styles = {
     paper: {
-        height: 200,
-        width: 200,
         margin: 20,
         textAlign: 'center',
         display: 'inline-block',
@@ -28,8 +26,19 @@ const styles = {
     },
     header: {
         fontSize: 22,
+    },
+    normalSize: {
+        height: 200,
+        width: 200,
+    },
+    smallSize: {
+        height: 200,
+        width: 100,
+    },
+    kingSize: {
+        height: 300,
+        width: 300,
     }
-
 };
 
 
@@ -41,6 +50,15 @@ export class Indicator extends Component {
     }
 
     render() {
+        const is_small = (this.props.small)?this.props.small:false;
+
+        const which_size = (is_small)? styles.smallSize : styles.normalSize;
+
+        const paper_style = Object.assign({
+            height: which_size.height,
+            width: which_size.width,
+        }, styles.paper);
+
         const {title, value} = this.props;
         const value_asInt = parseInt(value);
 
@@ -73,7 +91,7 @@ export class Indicator extends Component {
 
 
         return (
-            <Paper key={"invoice_"+title} style={styles.paper} zDepth={styles.paperDepth}>
+            <Paper key={"invoice_"+title} style={paper_style} zDepth={styles.paperDepth}>
                 <h3 style={styles.header}>{title}</h3>
                 <span style={styles.value}>{value}</span>
                 {visual_indicator}
@@ -90,4 +108,5 @@ Indicator.propTypes = {
     ]).isRequired,
     percentage: React.PropTypes.bool,
     total: React.PropTypes.number,
+    small: React.PropTypes.bool,
 };

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -23,6 +23,13 @@ const styles = {
         textAlign: 'center',
         overflow:'auto',
     },
+    value: {
+        fontSize: 35,
+    },
+    header: {
+        fontSize: 22,
+    }
+
 };
 
 
@@ -67,8 +74,8 @@ export class Indicator extends Component {
 
         return (
             <Paper key={"invoice_"+title} style={styles.paper} zDepth={styles.paperDepth}>
-                <h3>{title}</h3>
-                <p>{value}</p>
+                <h3 style={styles.header}>{title}</h3>
+                <span style={styles.value}>{value}</span>
                 {visual_indicator}
             </Paper>
         );

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,7 +385,7 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
-        const historical = proposal.historical;
+        const historical = (proposal.historical)?proposal.historical:true;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -435,6 +435,7 @@ export class Proposal extends Component {
 
         let data=null;
         let components=null;
+        summary = prediction.summary;
 
         if (prediction) {
             const predictionAdapted=adaptProposalData(prediction);
@@ -528,10 +529,10 @@ export class Proposal extends Component {
             )
 
 
-        const proposalDetail = (proposal.summary) &&
+        const proposalDetail = (summary) &&
             <div style={styles.cardSeparator}>
                 <ProposalDetail
-                    data={proposal.summary}
+                    data={summary}
                     open={detail_open}
                 />
             </div>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,7 +385,7 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
-        const historical = (proposal.historical)?proposal.historical:true;
+        const historical = (proposal.historical != null)?proposal.historical:true;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -530,18 +530,6 @@ export class Proposal extends Component {
             )
 
 
-        const proposalDetail = (summary) &&
-            <div style={styles.cardSeparator}>
-                <ProposalDetail
-                    data={summary}
-                    open={detail_open}
-                    avg_info={{
-                        'data': Object.assign([],data),
-                        'components': components,
-                    }}
-                />
-            </div>
-        ;
 
 
         // The Proposal graph!
@@ -552,7 +540,25 @@ export class Proposal extends Component {
                       <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
                       :
                       <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.animateChart} />
-                  :null
+                  :null;
+
+
+
+
+        const proposalDetail = (summary) &&
+          <div style={styles.cardSeparator}>
+              <ProposalDetail
+                  data={summary}
+                  open={detail_open}
+                  avg_info={{
+                      'data': data,
+                      'components': components,
+                  }}
+              />
+          </div>
+        ;
+
+
 
         // The resulting Proposal element
         const Proposal = () => (

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -549,10 +549,12 @@ export class Proposal extends Component {
         const proposalPicture =
             (withPicture)?
                 (proposal.prediction) &&
-                  (proposalTable)?
-                      <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
-                      :
-                      <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.animateChart} />
+                  (
+                      (proposalTable)?
+                          <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
+                          :
+                          <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.animateChart} />
+                  )
                   :null;
 
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -541,7 +541,7 @@ export class Proposal extends Component {
                     value: 3,
                 },
             ],
-            "tariff_total": 16,
+            "tariff_total": 42,
             "tariff_average": [
                 {
                     name:'20A',
@@ -559,6 +559,23 @@ export class Proposal extends Component {
                     name:'21DHA',
                     value: 3,
                 },
+                {
+                    name:'21DHS',
+                    value: 5,
+                },
+                {
+                    name:'30A',
+                    value: 3,
+                },
+                {
+                    name:'31A',
+                    value: 5,
+                },
+                {
+                    name:'20DHS',
+                    value: 3,
+                },
+
             ],
         }
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,7 +385,7 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
-        const historical = (proposal.historical)? proposal.historical : true;
+        const historical = proposal.historical;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
 
@@ -404,15 +404,12 @@ export class Proposal extends Component {
 
 
         let daysRange_toShow;
-
-        let day_string;
         if (historical == false) {
              daysRange_toShow = daysRangeFuture;
-             day_string = new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions);
         } else {
              daysRange_toShow = daysRange;
-             day_string = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions);
         }
+        const day_string = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions);
 
         const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange_toShow}]</span>
         const subtitle = <span>Using {days[dayOfProposal]} {day_string}</span>;

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -541,6 +541,25 @@ export class Proposal extends Component {
                     value: 3,
                 },
             ],
+            "tariff_total": 16,
+            "tariff_average": [
+                {
+                    name:'20A',
+                    value: 5,
+                },
+                {
+                    name:'20DHA',
+                    value: 3,
+                },
+                {
+                    name:'21A',
+                    value: 5,
+                },
+                {
+                    name:'21DHA',
+                    value: 3,
+                },
+            ],
         }
 
         const proposalDetail =

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -525,6 +525,18 @@ export class Proposal extends Component {
 
 
         const dataTest = {
+            "cups_total": 555,
+            "invoice_total": 8,
+            "invoice_types": [
+                {
+                    name:'F1',
+                    value: 5,
+                },
+                {
+                    name:'F5D',
+                    value: 3,
+                },
+            ],
         }
 
         const proposalDetail =

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -535,6 +535,10 @@ export class Proposal extends Component {
                 <ProposalDetail
                     data={summary}
                     open={detail_open}
+                    avg_info={{
+                        'data': data,
+                        'components': components,
+                    }}
                 />
             </div>
         ;

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -528,7 +528,7 @@ export class Proposal extends Component {
             )
 
 
-        const proposalDetail =
+        const proposalDetail = (proposal.summary) &&
             <div style={styles.cardSeparator}>
                 <ProposalDetail
                     data={proposal.summary}

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,7 +385,7 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
-        const historical = (proposal.historical == true)?true:false;
+        const historical = (proposal.historical == false)?false:true;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -435,7 +435,8 @@ export class Proposal extends Component {
 
         let data=null;
         let components=null;
-        summary = prediction.summary;
+
+        const summary = prediction.summary;
 
         if (prediction) {
             const predictionAdapted=adaptProposalData(prediction);

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -435,14 +435,14 @@ export class Proposal extends Component {
 
         let data=null;
         let components=null;
-
-        const summary = prediction.summary;
+        let summary = null;
 
         if (prediction) {
             const predictionAdapted=adaptProposalData(prediction);
             const current = predictionAdapted[aggregationSelected];
             data = current.result;
             components = current.components;
+            summary = (prediction.summary != undefined)?prediction.summary:null;
         }
 
         // The Proposal status!
@@ -544,8 +544,7 @@ export class Proposal extends Component {
 
 
 
-
-        const proposalDetail = (summary) &&
+        const proposalDetail = (summary != null) &&
           <div style={styles.cardSeparator}>
               <ProposalDetail
                   data={summary}

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,7 +385,11 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
+        const historical = (proposal.historical)? proposal.historical : true;
+
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
+
+        const daysRangeFuture = (historical)? null : new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range_future[1]).toLocaleDateString(locale, dateOptions);
 
         const lastExecution = new Date(proposal.execution_date).toLocaleString(locale, hourOptions);
         const creationDate = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
@@ -394,10 +398,24 @@ export class Proposal extends Component {
         const withPicture = (proposal.isNew)?!proposal.isNew:true;
 
         const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
-        const dayOfProposal = new Date(proposal.days_range[0]).getDay();
 
-        const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange}]</span>
-        const subtitle = <span>{days[dayOfProposal]} {new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions)}</span>;
+        const dayOfProposal = new Date(proposal.days_range[0]).getDay();
+        const dayOfProposalFuture = (historical) ? null : new Date(proposal.days_range_future[0]).getDay();
+
+
+        let daysRange_toShow;
+
+        let day_string;
+        if (historical == false) {
+             daysRange_toShow = daysRangeFuture;
+             day_string = new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions);
+        } else {
+             daysRange_toShow = daysRange;
+             day_string = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions);
+        }
+
+        const title = <span>{proposal.name}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[{daysRange_toShow}]</span>
+        const subtitle = <span>Using {days[dayOfProposal]} {day_string}</span>;
 
         const offset = (withPicture)?0:1;
         const size = (withPicture)?8:9;

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -385,11 +385,9 @@ export class Proposal extends Component {
 
         const proposalTable = this.state.proposalTable;
 
-        const historical = (proposal.historical != null)?proposal.historical:true;
+        const historical = (proposal.historical == true)?true:false;
 
         const daysRange = new Date(proposal.days_range[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range[1]).toLocaleDateString(locale, dateOptions);
-
-        const daysRangeFuture = (historical)? null : new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range_future[1]).toLocaleDateString(locale, dateOptions);
 
         const lastExecution = new Date(proposal.execution_date).toLocaleString(locale, hourOptions);
         const creationDate = new Date(proposal.creation_date).toLocaleString(locale, hourOptions);
@@ -402,10 +400,10 @@ export class Proposal extends Component {
         const dayOfProposal = new Date(proposal.days_range[0]).getDay();
         const dayOfProposalFuture = (historical) ? null : new Date(proposal.days_range_future[0]).getDay();
 
-
         let daysRange_toShow;
         if (historical == false) {
-             daysRange_toShow = daysRangeFuture;
+             daysRange_toShow = new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range_future[1]).toLocaleDateString(locale, dateOptions);
+
         } else {
              daysRange_toShow = daysRange;
         }

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -536,7 +536,7 @@ export class Proposal extends Component {
                     data={summary}
                     open={detail_open}
                     avg_info={{
-                        'data': data,
+                        'data': Object.assign({},data),
                         'components': components,
                     }}
                 />

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -528,57 +528,6 @@ export class Proposal extends Component {
             )
 
 
-        const dataTest = {
-            "cups_total": 555,
-            "invoice_total": 8,
-            "invoice_types": [
-                {
-                    name:'F1',
-                    value: 5,
-                },
-                {
-                    name:'F5D',
-                    value: 3,
-                },
-            ],
-            "tariff_total": 42,
-            "tariff_average": [
-                {
-                    name:'20A',
-                    value: 5,
-                },
-                {
-                    name:'20DHA',
-                    value: 3,
-                },
-                {
-                    name:'21A',
-                    value: 5,
-                },
-                {
-                    name:'21DHA',
-                    value: 3,
-                },
-                {
-                    name:'21DHS',
-                    value: 5,
-                },
-                {
-                    name:'30A',
-                    value: 3,
-                },
-                {
-                    name:'31A',
-                    value: 5,
-                },
-                {
-                    name:'20DHS',
-                    value: 3,
-                },
-
-            ],
-        }
-
         const proposalDetail =
             <div style={styles.cardSeparator}>
                 <ProposalDetail

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -71,6 +71,10 @@ const styles = {
     labelToggle: {
         marginTop: 7,
         marginLeft: 7,
+    },
+    cardSeparator: {
+        marginTop: 50,
+        marginBottom: 20,
     }
 };
 
@@ -540,10 +544,12 @@ export class Proposal extends Component {
         }
 
         const proposalDetail =
-            <ProposalDetail
-                data={dataTest}
-                open={detail_open}
-            />
+            <div style={styles.cardSeparator}>
+                <ProposalDetail
+                    data={dataTest}
+                    open={detail_open}
+                />
+            </div>
         ;
 
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -582,7 +582,7 @@ export class Proposal extends Component {
         const proposalDetail =
             <div style={styles.cardSeparator}>
                 <ProposalDetail
-                    data={dataTest}
+                    data={proposal.summary}
                     open={detail_open}
                 />
             </div>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -18,6 +18,8 @@ import { ProposalTag } from '../ProposalTag';
 import { ProposalGraph } from '../ProposalGraph';
 import { ProposalTableMaterial } from '../ProposalTableMaterial';
 
+import { ProposalDetail } from '../ProposalDetail';
+
 import { Notification } from '../Notification';
 import Dialog from 'material-ui/Dialog';
 
@@ -274,6 +276,18 @@ export class Proposal extends Component {
     };
 
 
+    toggleDetail = () => {
+        this.detail_open = !this.detail_open;
+
+        console.log("toggling", this.detail_open);
+        /*
+        this.setState({
+            message_open: true,
+            confirmation_open: false,
+        });
+        */
+    };
+
 
 
     duplicateProposalQuestion = (event, proposalID) => {
@@ -315,9 +329,6 @@ export class Proposal extends Component {
         this.props.duplicateProposal(token, proposalID);
     };
 
-
-
-
     deleteProposalQuestion = (event, proposalID) => {
         event.preventDefault();
         this.confirmation.confirmation_open = true;
@@ -357,9 +368,6 @@ export class Proposal extends Component {
         this.props.deleteProposal(token, proposalID);
     };
 
-
-
-
     handleConfirmation = (what, message, text) => {
         this.next = what;
         this.message = message
@@ -396,10 +404,15 @@ export class Proposal extends Component {
         const changeProposalAggregation=this.changeProposalAggregation;
         const aggregations = this.state.aggregations;
 
-        const refreshProposal=this.refreshProposalQuestion;
-        const reRunProposal=this.reRunProposalQuestion;
-        const duplicateProposal=this.duplicateProposalQuestion;
-        const deleteProposal=this.deleteProposalQuestion;
+        const refreshProposal = this.refreshProposalQuestion;
+        const reRunProposal = this.reRunProposalQuestion;
+        const duplicateProposal = this.duplicateProposalQuestion;
+        const deleteProposal = this.deleteProposalQuestion;
+
+        const toggleDetail = this.toggleDetail;
+
+        let detail_open = this.detail_open;
+
 
         const actionsButtons = [
           <FlatButton
@@ -510,6 +523,18 @@ export class Proposal extends Component {
             </div>
             )
 
+
+        const dataTest = {
+        }
+
+        const proposalDetail =
+            <ProposalDetail
+                data={dataTest}
+                open={detail_open}
+            />
+        ;
+
+
         // The Proposal graph!
         const proposalPicture =
             (withPicture)?
@@ -550,12 +575,14 @@ export class Proposal extends Component {
 
           {proposalPicture}
 
+          {proposalDetail}
+
           {
               !readOnly &&
               <CardActions>
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
                 <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
-                <FlatButton label="Detail" icon={<DetailIcon/>} disabled/>
+                <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
                 <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
                 <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -536,7 +536,7 @@ export class Proposal extends Component {
                     data={summary}
                     open={detail_open}
                     avg_info={{
-                        'data': Object.assign({},data),
+                        'data': Object.assign([],data),
                         'components': components,
                     }}
                 />

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -27,8 +27,8 @@ const styles = {
 };
 
 const today = new Date();
-const date_limit_inf = new Date(today.getFullYear() - 4, 1, 1);
-const date_limit_sup = new Date(today.getFullYear() + 4, 12, 31);
+const date_limit_inf = new Date(today.getFullYear() - 6, 1, 1);
+const date_limit_sup = new Date(today.getFullYear() + 6, 12, 31);
 
 const validations = {
     name: {

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -98,8 +98,9 @@ export class ProposalDefinition extends Component {
 
       (element_type == "historic") &&
         minDate.setFullYear(minDate.getFullYear() - 1);
-      //minDate.setHours(0, 0, 0, 0);
 
+      minDate.setHours(0, 0, 0, 0);
+      
       this.state = {
           type: types[element_type],
           loading: false,

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -59,6 +59,16 @@ const validations = {
     },
 }
 
+const types = {
+    "proposal": {
+        "name": "proposal",
+        "plural": "proposals",
+    },
+    "historic": {
+        "name": "historic",
+        "plural": "historics",
+    },
+}
 
 function mapStateToProps(state) {
     return {
@@ -82,11 +92,15 @@ export class ProposalDefinition extends Component {
           aggregations_list.push( false );
       });
 
+      const element_type = (props.type)?props.type:"proposal";
+
       const minDate = new Date();
       minDate.setFullYear(minDate.getFullYear() - 1);
       //minDate.setHours(0, 0, 0, 0);
 
+
       this.state = {
+          type: types[element_type],
           loading: false,
           finished: false,
           stepIndex: 0,
@@ -106,7 +120,9 @@ export class ProposalDefinition extends Component {
           readyToNext: false,
       };
       this.stepsLength = this.getSteps().length;
+      console.log(this.state.type);
     }
+
 
     componentWillMount = () => {
         //select all by default
@@ -157,8 +173,8 @@ export class ProposalDefinition extends Component {
                 title: "Name",
                 content: (
                     <div>
-                        <p>We need some details to create a new Proposal.</p>
-                        <p>Please, <b>insert the name</b> of your proposal in the following field:</p>
+                        <p>We need some details to create a new {this.state.type.name}.</p>
+                        <p>Please, <b>insert the name</b> of your {this.state.type.name} in the following field:</p>
                         <TextField
                             style={{marginTop: 0}}
                             floatingLabelText="Proposal name"

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -95,9 +95,10 @@ export class ProposalDefinition extends Component {
       const element_type = (props.type)?props.type:"proposal";
 
       const minDate = new Date();
-      minDate.setFullYear(minDate.getFullYear() - 1);
-      //minDate.setHours(0, 0, 0, 0);
 
+      (element_type == "historic") &&
+        minDate.setFullYear(minDate.getFullYear() - 1);
+      //minDate.setHours(0, 0, 0, 0);
 
       this.state = {
           type: types[element_type],
@@ -119,6 +120,7 @@ export class ProposalDefinition extends Component {
           aggregations_error_text: null,
           readyToNext: false,
       };
+
       this.stepsLength = this.getSteps().length;
       console.log(this.state.type);
     }

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -96,12 +96,17 @@ export class ProposalDefinition extends Component {
 
       const minDate = new Date();
 
-      (element_type == "historic") &&
-        minDate.setFullYear(minDate.getFullYear() - 1);
+      let createMethod = props.createProposal;
 
-      minDate.setHours(0, 0, 0, 0);
-      
+      if (element_type == "historic") {
+        minDate.setFullYear(minDate.getFullYear() - 1);
+        createMethod = props.createHistoricProposal;
+      }
+
+      //minDate.setHours(0, 0, 0, 0);
+
       this.state = {
+          createMethod: createMethod,
           type: types[element_type],
           loading: false,
           finished: false,
@@ -615,7 +620,8 @@ export class ProposalDefinition extends Component {
             },
         }
 
-        this.props.createProposal(token, proposalData);
+
+        this.state.createMethod(token, proposalData);
     }
 
     render() {

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -8,6 +8,8 @@ import InvoicesIcon from 'material-ui/svg-icons/editor/format-list-numbered';
 import {orange400} from 'material-ui/styles/colors';
 
 import { Indicator } from '../Indicator';
+import { ProposalTableMaterial } from '../ProposalTableMaterial';
+import {adaptProposalData} from '../../utils/graph';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
@@ -35,6 +37,7 @@ export class ProposalDetail extends Component {
 
     render() {
         const data = this.props.data;
+        const avg_info = this.props.avg_info;
 
         //open it by default
         const open = (this.props.open)?this.props.open:true;
@@ -60,6 +63,7 @@ export class ProposalDetail extends Component {
 
 
         //handle tariff count
+        let cups_per_tariff = {};
         const tariff_count = (data.tariff_count) &&
 
             Object.keys(data.tariff_count).map(function(i) {
@@ -70,6 +74,8 @@ export class ProposalDetail extends Component {
                 const original_position =  entry['position'];
 
                 const color = colors[original_position];
+
+                cups_per_tariff[component_name] = component_value;
 
                 return (
                     <Indicator
@@ -95,6 +101,7 @@ export class ProposalDetail extends Component {
                 />
             );
 
+
         //Prepare Invoices count
         const num_invoices =  (data.invoice_total) &&
             (
@@ -104,6 +111,25 @@ export class ProposalDetail extends Component {
                     icon={<InvoicesIcon style={styles.icon}/>}
                 />
             );
+
+
+        // Calc the AVG per tariff (tariff / num_cups)
+        for (var hora=0; hora<avg_info.data.length; hora++){
+            let una_hora = avg_info.data[hora];
+            
+            Object.keys(una_hora).map(function(agg) {
+                const num_cups = cups_per_tariff[agg];
+
+                if (agg != "total" && agg != "name")
+                    una_hora[agg] = (una_hora[agg] / num_cups).toFixed(4).toString().replace(".", ",");
+            });
+        }
+
+
+        const avg_tariff_table = (data.tariff_count) &&
+            <ProposalTableMaterial stacked={true} data={avg_info.data} components={avg_info.components} height={500} />
+
+
 
         return (
             open &&
@@ -119,6 +145,11 @@ export class ProposalDetail extends Component {
                     <div>
                         <h3>TARIFF COUNT</h3>
                         {tariff_count}
+                    </div>
+
+                    <div>
+                        <h3>TARIFF AVG</h3>
+                        {avg_tariff_table}
                     </div>
 
                 </div>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -1,6 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+
+import CupsIcon from 'material-ui/svg-icons/communication/contacts';
+import InvoicesIcon from 'material-ui/svg-icons/editor/format-list-numbered';
+
+import {orange400} from 'material-ui/styles/colors';
+
 import { Indicator } from '../Indicator';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
@@ -8,6 +14,15 @@ import { Indicator } from '../Indicator';
 import {colors} from '../../constants';
 
 const styles = {
+    center: {
+        textAlign: 'center',
+    },
+    icon: {
+        color: orange400,
+        width: 50,
+        height: 50,
+        fontSize: 20,
+    },
 };
 
 
@@ -32,8 +47,11 @@ export class ProposalDetail extends Component {
 
                 return (
                     <Indicator
+                        key={"indicator_"+component_name}
                         title={component_name}
                         value={component_value}
+                        total={data.invoice_total}
+                        percentage={true}
                     />
                 )
             });
@@ -44,6 +62,7 @@ export class ProposalDetail extends Component {
                 <Indicator
                     title="CUPS"
                     value={data.cups_total}
+                    icon={<CupsIcon style={styles.icon}/>}
                 />
             );
 
@@ -53,12 +72,13 @@ export class ProposalDetail extends Component {
                 <Indicator
                     title="Invoices"
                     value={data.invoice_total}
+                    icon={<InvoicesIcon style={styles.icon}/>}
                 />
             );
 
         return (
             open &&
-                <div >
+                <div style={styles.center}>
                     {num_cups}
 
                     {num_invoices}

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -114,9 +114,11 @@ export class ProposalDetail extends Component {
                     {num_invoices}
 
                     {invoice_types}
+                    <br/>
+                        <br/>
 
                     <div>
-                        <h3>TARIFF AVERAGES</h3>
+                        <h3>TARIFF COUNT</h3>
                         {tariff_average}
                     </div>
 

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -42,8 +42,10 @@ export class ProposalDetail extends Component {
         //handle invoice types
         const invoice_types = (data.invoice_types) &&
             Object.keys(data.invoice_types).map(function(component, i) {
-                const component_name = data.invoice_types[component].name;
-                const component_value =  data.invoice_types[component].value;
+
+                const component_name = component
+                const component_value =  data.invoice_types[component];
+
 
                 return (
                     <Indicator

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -61,23 +61,40 @@ export class ProposalDetail extends Component {
                 )
             });
 
-        //Prepare headers
-        const num_cups = (
-            <Paper style={styles.paper} zDepth={styles.paperDepth}>
-                <div className="inner">
-                  <h3>150</h3>
-                  <p>CUPS</p>
-                </div>
-                <div className="icon">
-                  <i className="ion ion-bag"></i>
-                </div>
-            </Paper>
-        );
+        //Prepare CUPS count
+        const num_cups = (data.cups_total) &&
+            (
+                <Paper style={styles.paper} zDepth={styles.paperDepth}>
+                    <div className="inner">
+                      <h3>{data.cups_total}</h3>
+                      <p>CUPS</p>
+                    </div>
+                    <div className="icon">
+                      <i className="ion ion-bag"></i>
+                    </div>
+                </Paper>
+            );
+
+        //Prepare Invoices count
+        const num_invoices =  (data.invoice_total) &&
+            (
+                <Paper style={styles.paper} zDepth={styles.paperDepth}>
+                    <div className="inner">
+                      <h3>{data.invoice_total}</h3>
+                      <p>Invoices</p>
+                    </div>
+                    <div className="icon">
+                      <i className="ion ion-bag"></i>
+                    </div>
+                </Paper>
+            );
 
         return (
             open &&
                 <div >
                     {num_cups}
+
+                    {num_invoices}
 
                     {invoice_types}
                 </div>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -64,6 +64,15 @@ export class ProposalDetail extends Component {
                 const component_name = data.tariff_average[component].name;
                 const component_value =  data.tariff_average[component].value;
 
+                const color = colors[i];
+
+                /*
+                const icon_style = Object.assign({
+                    color: color,
+                }, styles.icon);
+                */
+
+
                 return (
                     <Indicator
                         key={"indicator_"+component_name}
@@ -72,6 +81,7 @@ export class ProposalDetail extends Component {
                         total={data.tariff_total}
                         percentage={true}
                         small={true}
+                        color={color}
                     />
                 )
             });

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -59,20 +59,13 @@ export class ProposalDetail extends Component {
         });
 
 
-        //handle tariff average
-        const tariff_average = (data.tariff_average) &&
-            Object.keys(data.tariff_average).map(function(component, i) {
-                const component_name = data.tariff_average[component].name;
-                const component_value =  data.tariff_average[component].value;
+        //handle tariff count
+        const tariff_count = (data.tariff_count) &&
+            Object.keys(data.tariff_count).map(function(component, i) {
+                const component_name = component;
+                const component_value =  data.tariff_count[component];
 
                 const color = colors[i];
-
-                /*
-                const icon_style = Object.assign({
-                    color: color,
-                }, styles.icon);
-                */
-
 
                 return (
                     <Indicator

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -54,7 +54,27 @@ export class ProposalDetail extends Component {
                         percentage={true}
                     />
                 )
+        });
+
+
+        //handle tariff average
+        const tariff_average = (data.tariff_average) &&
+            Object.keys(data.tariff_average).map(function(component, i) {
+                console.log(data.tariff_average[component]);
+                const component_name = data.tariff_average[component].name;
+                const component_value =  data.tariff_average[component].value;
+
+                return (
+                    <Indicator
+                        key={"indicator_"+component_name}
+                        title={component_name}
+                        value={component_value}
+                        total={data.tariff_total}
+                        percentage={true}
+                    />
+                )
             });
+
 
         //Prepare CUPS count
         const num_cups = (data.cups_total) &&
@@ -84,6 +104,12 @@ export class ProposalDetail extends Component {
                     {num_invoices}
 
                     {invoice_types}
+
+                    <div>
+                        <h3>TARIFF AVERAGES</h3>
+                        {tariff_average}
+                    </div>
+
                 </div>
         );
     }

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -9,7 +9,6 @@ import {orange400} from 'material-ui/styles/colors';
 
 import { Indicator } from '../Indicator';
 import { ProposalTableMaterial } from '../ProposalTableMaterial';
-import {adaptProposalData} from '../../utils/graph';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
@@ -113,9 +112,13 @@ export class ProposalDetail extends Component {
             );
 
 
+
+        let table_data = []
         // Calc the AVG per tariff (tariff / num_cups)
-        for (var hora=0; hora<avg_info.data.length; hora++){
-            let una_hora = avg_info.data[hora];
+        for (var hora = 0; hora < avg_info.data.length; hora++){
+
+            //Duplicate table data memspaces to avoid corruptions
+            let una_hora = Object.assign([], avg_info.data[hora]);
 
             Object.keys(una_hora).map(function(agg) {
                 const num_cups = cups_per_tariff[agg];
@@ -123,11 +126,12 @@ export class ProposalDetail extends Component {
                 if (agg != "total" && agg != "name")
                     una_hora[agg] = (una_hora[agg] / num_cups).toFixed(4).toString().replace(".", ",");
             });
+
+            table_data[hora] = una_hora;
         }
 
-
         const avg_tariff_table = (data.tariff_count) &&
-            <ProposalTableMaterial stacked={true} data={avg_info.data} components={avg_info.components} height={500} totals={false}/>
+            <ProposalTableMaterial stacked={true} data={table_data} components={avg_info.components} height={500} totals={false}/>
 
 
         return (

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
 import Paper from 'material-ui/Paper';
+import CircularProgress from 'material-ui/CircularProgress';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
@@ -41,33 +42,51 @@ export class ProposalDetail extends Component {
         //open it by default
         const open = (this.props.open)?this.props.open:true;
 
+        //handle invoice types
+        const invoice_types = (data.invoice_types) &&
+            Object.keys(data.invoice_types).map(function(component, i) {
+                const component_name = data.invoice_types[component].name;
+                const component_value =  data.invoice_types[component].value;
+
+                return (
+                    <Paper key={"invoice_"+component} style={styles.paper} zDepth={styles.paperDepth}>
+                        <div className="inner">
+                          <h3>{component_name}</h3>
+                          <p>{component_value}</p>
+                        </div>
+                        <div className="icon">
+                          <i className="ion ion-bag"></i>
+                        </div>
+                    </Paper>
+                )
+            });
+
         //Prepare headers
         const num_cups = (
-            <div>
-                <Paper style={styles.paper} zDepth={styles.paperDepth}>
-                    <div class="inner">
-                      <h3>150</h3>
-                      <p>CUPS</p>
-                    </div>
-                    <div class="icon">
-                      <i class="ion ion-bag"></i>
-                    </div>
-                </Paper>
-
-            </div>
+            <Paper style={styles.paper} zDepth={styles.paperDepth}>
+                <div className="inner">
+                  <h3>150</h3>
+                  <p>CUPS</p>
+                </div>
+                <div className="icon">
+                  <i className="ion ion-bag"></i>
+                </div>
+            </Paper>
         );
 
         return (
             open &&
                 <div >
                     {num_cups}
+
+                    {invoice_types}
                 </div>
         );
     }
 }
 
 ProposalDetail.propTypes = {
-    data: React.PropTypes.array.isRequired,
+    data: React.PropTypes.object.isRequired,
     open: React.PropTypes.bool,
     colors: React.PropTypes.object,
 };

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
+import Paper from 'material-ui/Paper';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
@@ -15,7 +16,15 @@ const styles = {
     hourColor: {
         color: 'white',
         backgroundColor: '#BBBBBB',
-    }
+    },
+    paper: {
+        height: 150,
+        width: 150,
+        margin: 20,
+        textAlign: 'center',
+        display: 'inline-block',
+    },
+    paperDepth: 4,
 };
 
 
@@ -35,7 +44,16 @@ export class ProposalDetail extends Component {
         //Prepare headers
         const num_cups = (
             <div>
-                asasd
+                <Paper style={styles.paper} zDepth={styles.paperDepth}>
+                    <div class="inner">
+                      <h3>150</h3>
+                      <p>CUPS</p>
+                    </div>
+                    <div class="icon">
+                      <i class="ion ion-bag"></i>
+                    </div>
+                </Paper>
+
             </div>
         );
 

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -71,6 +71,7 @@ export class ProposalDetail extends Component {
                         value={component_value}
                         total={data.tariff_total}
                         percentage={true}
+                        small={true}
                     />
                 )
             });

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -1,0 +1,55 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
+
+//import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
+
+import {colors} from '../../constants';
+
+const styles = {
+    selectedElement: {
+        color: 'white',
+        backgroundColor: '#808080',
+    },
+    hourColor: {
+        color: 'white',
+        backgroundColor: '#BBBBBB',
+    }
+};
+
+
+export class ProposalDetail extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+        };
+    }
+
+    render() {
+        const data = this.props.data;
+
+        //open it by default
+        const open = (this.props.open)?this.props.open:true;
+
+        //Prepare headers
+        const num_cups = (
+            <div>
+                asasd
+            </div>
+        );
+
+        return (
+            open &&
+                <div >
+                    {num_cups}
+                </div>
+        );
+    }
+}
+
+ProposalDetail.propTypes = {
+    data: React.PropTypes.array.isRequired,
+    open: React.PropTypes.bool,
+    colors: React.PropTypes.object,
+};

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -116,7 +116,7 @@ export class ProposalDetail extends Component {
         // Calc the AVG per tariff (tariff / num_cups)
         for (var hora=0; hora<avg_info.data.length; hora++){
             let una_hora = avg_info.data[hora];
-            
+
             Object.keys(una_hora).map(function(agg) {
                 const num_cups = cups_per_tariff[agg];
 
@@ -127,8 +127,7 @@ export class ProposalDetail extends Component {
 
 
         const avg_tariff_table = (data.tariff_count) &&
-            <ProposalTableMaterial stacked={true} data={avg_info.data} components={avg_info.components} height={500} />
-
+            <ProposalTableMaterial stacked={true} data={avg_info.data} components={avg_info.components} height={500} totals={false}/>
 
 
         return (
@@ -140,12 +139,16 @@ export class ProposalDetail extends Component {
 
                     {invoice_types}
                     <br/>
-                        <br/>
+                    <br/>
+                    <br/>
 
                     <div>
                         <h3>TARIFF COUNT</h3>
                         {tariff_count}
                     </div>
+
+                    <br/>
+                    <br/>
 
                     <div>
                         <h3>TARIFF AVG</h3>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -164,4 +164,5 @@ ProposalDetail.propTypes = {
     data: React.PropTypes.object.isRequired,
     open: React.PropTypes.bool,
     colors: React.PropTypes.object,
+    avg_info: React.PropTypes.object,
 };

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -124,7 +124,7 @@ export class ProposalDetail extends Component {
                 const num_cups = cups_per_tariff[agg];
 
                 if (agg != "total" && agg != "name")
-                    una_hora[agg] = (una_hora[agg] / num_cups).toFixed(4).toString().replace(".", ",");
+                    una_hora[agg] = (una_hora[agg] / num_cups).toFixed(4).toString()//.replace(".", ",");
             });
 
             table_data[hora] = una_hora;

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -61,11 +61,15 @@ export class ProposalDetail extends Component {
 
         //handle tariff count
         const tariff_count = (data.tariff_count) &&
-            Object.keys(data.tariff_count).map(function(component, i) {
-                const component_name = component;
-                const component_value =  data.tariff_count[component];
 
-                const color = colors[i];
+            Object.keys(data.tariff_count).map(function(i) {
+                const entry = data.tariff_count[i];
+
+                const component_name = entry['name'];
+                const component_value =  entry['count'];
+                const original_position =  entry['position'];
+
+                const color = colors[original_position];
 
                 return (
                     <Indicator
@@ -114,7 +118,7 @@ export class ProposalDetail extends Component {
 
                     <div>
                         <h3>TARIFF COUNT</h3>
-                        {tariff_average}
+                        {tariff_count}
                     </div>
 
                 </div>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -1,31 +1,13 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
-import Paper from 'material-ui/Paper';
-import CircularProgress from 'material-ui/CircularProgress';
+import { Indicator } from '../Indicator';
 
 //import { updatePaths, toggleName, removeNode, changeOffset } from '../../actions/proposalGraph';
 
 import {colors} from '../../constants';
 
 const styles = {
-    selectedElement: {
-        color: 'white',
-        backgroundColor: '#808080',
-    },
-    hourColor: {
-        color: 'white',
-        backgroundColor: '#BBBBBB',
-    },
-    paper: {
-        height: 150,
-        width: 150,
-        margin: 20,
-        textAlign: 'center',
-        display: 'inline-block',
-    },
-    paperDepth: 4,
 };
 
 
@@ -49,44 +31,29 @@ export class ProposalDetail extends Component {
                 const component_value =  data.invoice_types[component].value;
 
                 return (
-                    <Paper key={"invoice_"+component} style={styles.paper} zDepth={styles.paperDepth}>
-                        <div className="inner">
-                          <h3>{component_name}</h3>
-                          <p>{component_value}</p>
-                        </div>
-                        <div className="icon">
-                          <i className="ion ion-bag"></i>
-                        </div>
-                    </Paper>
+                    <Indicator
+                        title={component_name}
+                        value={component_value}
+                    />
                 )
             });
 
         //Prepare CUPS count
         const num_cups = (data.cups_total) &&
             (
-                <Paper style={styles.paper} zDepth={styles.paperDepth}>
-                    <div className="inner">
-                      <h3>{data.cups_total}</h3>
-                      <p>CUPS</p>
-                    </div>
-                    <div className="icon">
-                      <i className="ion ion-bag"></i>
-                    </div>
-                </Paper>
+                <Indicator
+                    title="CUPS"
+                    value={data.cups_total}
+                />
             );
 
         //Prepare Invoices count
         const num_invoices =  (data.invoice_total) &&
             (
-                <Paper style={styles.paper} zDepth={styles.paperDepth}>
-                    <div className="inner">
-                      <h3>{data.invoice_total}</h3>
-                      <p>Invoices</p>
-                    </div>
-                    <div className="icon">
-                      <i className="ion ion-bag"></i>
-                    </div>
-                </Paper>
+                <Indicator
+                    title="Invoices"
+                    value={data.invoice_total}
+                />
             );
 
         return (

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -60,7 +60,6 @@ export class ProposalDetail extends Component {
         //handle tariff average
         const tariff_average = (data.tariff_average) &&
             Object.keys(data.tariff_average).map(function(component, i) {
-                console.log(data.tariff_average[component]);
                 const component_name = data.tariff_average[component].name;
                 const component_value =  data.tariff_average[component].value;
 
@@ -76,7 +75,7 @@ export class ProposalDetail extends Component {
                 return (
                     <Indicator
                         key={"indicator_"+component_name}
-                        title={component_name}
+                        title={ (component_name!="")?component_name:"Empty"}
                         value={component_value}
                         total={data.tariff_total}
                         percentage={true}

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -92,6 +92,8 @@ export class ProposalGraph extends Component {
         const data = this.props.data;
         const components = this.props.components;
 
+        const howManyComponents = Object.keys(components).length;
+
         const stacked = (this.props.stacked)?"1":null;
 
         const height = (this.props.height)?this.props.height:500;
@@ -170,7 +172,12 @@ export class ProposalGraph extends Component {
               });
 
               const line = <Line type='monotone' dataKey='total' stroke='#000000' unit={unit} />;
-              const legend = <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>;
+
+              //avoid showing legend if there are too many elements to show
+              const legend = (howManyComponents < 55) ?
+                <Legend width={100} layout="horizontal" align="center" wrapperStyle={styles.legend}/>
+                :
+                null;
 
               const xaxis = <XAxis dataKey="name" label={"Hour"}/>;
               const xaxisLite = <XAxis dataKey="name"/>;

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -12,11 +12,23 @@ const styles = {
     selectedElement: {
         color: 'white',
         backgroundColor: '#808080',
+        textAlign: 'center',
+
     },
     hourColor: {
         color: 'white',
         backgroundColor: '#BBBBBB',
-    }
+        textAlign: 'right',
+    },
+    alignCenter: {
+        textAlign: 'center',
+    },
+    alignLeft: {
+        textAlign: 'left',
+    },
+    alignRight: {
+        textAlign: 'right',
+    },
 };
 
 
@@ -40,7 +52,12 @@ export class ProposalTableMaterial extends Component {
             const text_color = (colors[i] == "#000000")?'white':'black';
 
             return (
-                <TableRowColumn key={"header"+i} style={{backgroundColor: colors[i], color: text_color }} stroke={colors[i]} fill={colors[i]}>
+                <TableRowColumn
+                    key={"header"+i}
+                    style={{backgroundColor: colors[i], color: text_color, textAlign: styles.alignCenter.textAlign }} 
+                    stroke={colors[i]}
+                    fill={colors[i]}
+                >
                     <b>{component}</b>
                 </TableRowColumn>
             )
@@ -80,7 +97,10 @@ export class ProposalTableMaterial extends Component {
             componentsKeys.map(function (comp, j) {
                 let value = (data[i][comp])?data[i][comp]:0;
                 cells.push(
-                    <TableRowColumn key={"Column"+i+j}>
+                    <TableRowColumn
+                        key={"Column"+i+j}
+                        style={styles.alignCenter}
+                    >
                         {value}
                     </TableRowColumn>
                 );
@@ -120,7 +140,10 @@ export class ProposalTableMaterial extends Component {
             //Prepare the last row with the TOTALS
             allTotalSum.map( function (component, z) {
                 totalRow.push (
-                    <TableRowColumn key={"tableRowTotal"+z}>
+                    <TableRowColumn
+                        key={"tableRowTotal"+z}
+                        style={styles.alignCenter}
+                    >
                         {component}
                     </TableRowColumn>
                 );
@@ -133,13 +156,19 @@ export class ProposalTableMaterial extends Component {
                     style={styles.selectedElement}
                     selectable={false}>
 
-                    <TableRowColumn key={"tableRowTotalHeader"}>
+                    <TableRowColumn
+                        key={"tableRowTotalHeader"}
+                        style={styles.alignRight}
+                    >
                         <b>TOTAL</b>
                     </TableRowColumn>
 
                     {totalRow}
 
-                    <TableRowColumn key={"tableRowTotalHeader"}>
+                    <TableRowColumn
+                        key={"tableRowTotalHeader"}
+                        style={styles.alignCenter}
+                    >
                         <b>{totalSum}</b>
                     </TableRowColumn>
                 </TableRow>

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -35,11 +35,12 @@ export class ProposalTableMaterial extends Component {
         //Add totals by default
         const totals = (typeof this.props.totals !== 'undefined')?this.props.totals:true;
 
-
         //Prepare headers
         const headers = Object.keys(components).map(function(component, i) {
+            const text_color = (colors[i] == "#000000")?'white':'black';
+
             return (
-                <TableRowColumn key={"header"+i} style={{backgroundColor: colors[i] }} stroke={colors[i]} fill={colors[i]}>
+                <TableRowColumn key={"header"+i} style={{backgroundColor: colors[i], color: text_color }} stroke={colors[i]} fill={colors[i]}>
                     <b>{component}</b>
                 </TableRowColumn>
             )

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -50,6 +50,25 @@ export class ProposalTableMaterial extends Component {
         //Add totals by default
         const totals = (typeof this.props.totals !== 'undefined')?this.props.totals:true;
 
+
+        const howManyComponents = Object.keys(components).length;
+
+        if (howManyComponents > 18) {
+            return (
+                <div>
+                    <br/>
+                    <p>
+                        Sorry, but <strong>there too many components</strong> to render using this aggregation, and the <strong>table will be un-usable</strong>.
+                    </p>
+
+                    <p>
+                        Change to chart view or select another aggregation to review their related table.
+                    </p>
+                    <br/>
+                </div>
+            );
+        }
+
         //Prepare headers
         const headers = Object.keys(components).map(function(component, i) {
             const text_color = (colors[i] == "#000000")?'white':'black';
@@ -121,7 +140,7 @@ export class ProposalTableMaterial extends Component {
                 cells.push(
                     <TableRowColumn
                         key={"Column"+i+"TOTAL"}
-                        style={ Object.assign({},styles.selectedElement, {textOverflow:styles.alignCenter.textOverflow})} 
+                        style={ Object.assign({},styles.selectedElement, {textOverflow:styles.alignCenter.textOverflow})}
                     >
                         <b>{totalSum}</b>
                     </TableRowColumn>

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -22,6 +22,7 @@ const styles = {
     },
     alignCenter: {
         textAlign: 'center',
+        textOverflow: '',
     },
     alignLeft: {
         textAlign: 'left',

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -32,6 +32,10 @@ export class ProposalTableMaterial extends Component {
         const components = this.props.components;
         const type = (this.props.type)?this.props.type:null;
 
+        //Add totals by default
+        const totals = (typeof this.props.totals !== 'undefined')?this.props.totals:true;
+
+
         //Prepare headers
         const headers = Object.keys(components).map(function(component, i) {
             return (
@@ -41,7 +45,7 @@ export class ProposalTableMaterial extends Component {
             )
         });
 
-        const headerTotal = (
+        const headerTotal = (totals) && (
             <TableRowColumn
                 key={"headerTotal"}
                 style={styles.selectedElement}
@@ -71,6 +75,7 @@ export class ProposalTableMaterial extends Component {
             );
 
             let totalSum = 0;
+
             componentsKeys.map(function (comp, j) {
                 let value = (data[i][comp])?data[i][comp]:0;
                 cells.push(
@@ -86,15 +91,18 @@ export class ProposalTableMaterial extends Component {
                 allTotalSum[j] += value;
             })
 
-            // Push the total for this row
-            cells.push(
-                <TableRowColumn
-                    key={"Column"+i+"TOTAL"}
-                    style={styles.selectedElement}
-                >
-                    <b>{totalSum}</b>
-                </TableRowColumn>
-            )
+            if (totals) {
+
+                // Push the total for this row
+                cells.push(
+                    <TableRowColumn
+                        key={"Column"+i+"TOTAL"}
+                        style={styles.selectedElement}
+                    >
+                        <b>{totalSum}</b>
+                    </TableRowColumn>
+                )
+            }
 
             rows.push (
                 <TableRow key={"tableRow"+i}>
@@ -103,34 +111,39 @@ export class ProposalTableMaterial extends Component {
             );
         }
 
-        let totalRow = [];
-        let totalSum = 0;
-        //Prepare the last row with the TOTALS
-        allTotalSum.map( function (component, z) {
-            totalRow.push (
-                <TableRowColumn key={"tableRowTotal"+z}>
-                    {component}
-                </TableRowColumn>
+
+        if (totals) {
+            let totalRow = [];
+            let totalSum = 0;
+
+            //Prepare the last row with the TOTALS
+            allTotalSum.map( function (component, z) {
+                totalRow.push (
+                    <TableRowColumn key={"tableRowTotal"+z}>
+                        {component}
+                    </TableRowColumn>
+                );
+                totalSum += component;
+            })
+
+            rows.push (
+                <TableRow
+                    key={"tableRowTotal"}
+                    style={styles.selectedElement}
+                    selectable={false}>
+
+                    <TableRowColumn key={"tableRowTotalHeader"}>
+                        <b>TOTAL</b>
+                    </TableRowColumn>
+
+                    {totalRow}
+
+                    <TableRowColumn key={"tableRowTotalHeader"}>
+                        <b>{totalSum}</b>
+                    </TableRowColumn>
+                </TableRow>
             );
-            totalSum += component;
-        })
-
-        rows.push (
-            <TableRow
-                key={"tableRowTotal"}
-                style={styles.selectedElement}
-                selectable={false}>
-                <TableRowColumn key={"tableRowTotalHeader"}>
-                    <b>TOTAL</b>
-                </TableRowColumn>
-
-                {totalRow}
-
-                <TableRowColumn key={"tableRowTotalHeader"}>
-                    <b>{totalSum}</b>
-                </TableRowColumn>
-            </TableRow>
-        );
+        }
 
         return (
             <div >
@@ -164,4 +177,5 @@ ProposalTableMaterial.propTypes = {
     components: React.PropTypes.object.isRequired,
     colors: React.PropTypes.object,
     type: React.PropTypes.bool,
+    totals: React.PropTypes.bool,
 };

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -121,7 +121,7 @@ export class ProposalTableMaterial extends Component {
                 cells.push(
                     <TableRowColumn
                         key={"Column"+i+"TOTAL"}
-                        style={styles.selectedElement}
+                        style={ Object.assign({},styles.selectedElement, {textOverflow:styles.alignCenter.textOverflow})} 
                     >
                         <b>{totalSum}</b>
                     </TableRowColumn>

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -29,6 +29,8 @@ const styles = {
     alignRight: {
         textAlign: 'right',
     },
+    hourColumn: {
+    },
 };
 
 
@@ -54,7 +56,7 @@ export class ProposalTableMaterial extends Component {
             return (
                 <TableRowColumn
                     key={"header"+i}
-                    style={{backgroundColor: colors[i], color: text_color, textAlign: styles.alignCenter.textAlign }} 
+                    style={{backgroundColor: colors[i], color: text_color, textAlign: styles.alignCenter.textAlign }}
                     stroke={colors[i]}
                     fill={colors[i]}
                 >
@@ -86,7 +88,7 @@ export class ProposalTableMaterial extends Component {
             cells.push(
                 <TableRowColumn
                     key={"Column"+i}
-                    style={styles.hourColor}
+                    style={ Object.assign({},styles.hourColor, {width:styles.hourColumn.width})}
                 >
                     {data[i].name}
                 </TableRowColumn>
@@ -185,7 +187,8 @@ export class ProposalTableMaterial extends Component {
                         <TableRow key="headersRow">
                             <TableRowColumn
                                 key={"headerHour"}
-                                style={styles.hourColor}
+                                style={ Object.assign({},styles.hourColor, {width:styles.hourColumn.width})}
+
                             >
                                 <b>Hour</b>
                             </TableRowColumn>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,8 +3,8 @@ import React from 'react';
 import {debug} from './debug';
 export const DEBUG = (debug)?debug:false;
 
-export const VERSION = "0.4.0";
-export const VERSION_PR = "120";
+export const VERSION = "0.5.0";
+export const VERSION_PR = "134";
 
 export const API_SPECIFICATION = 1;
 export const API_PREFIX = "/api/v" + API_SPECIFICATION;

--- a/src/routes.js
+++ b/src/routes.js
@@ -14,6 +14,7 @@ import NotFound from './components/NotFound';
 import Proposals from './components/ProposalsView';
 import Proposal from './components/ProposalView';
 import ProposalNew from './components/ProposalNewView';
+import HistoryNewView from './components/HistoryNewView';
 import Profile from './components/ProfileView';
 import About from './components/AboutView';
 import Aggregations from './components/AggregationsView';
@@ -31,6 +32,7 @@ export default (
         <Route path="history" component={requireAuthentication(Analytics)} />
         <Route path="proposals" component={requireAuthentication(Proposals)} />
         <Route path="proposals/new" component={requireAuthentication(ProposalNew)} />
+        <Route path="historics/new" component={requireAuthentication(HistoryNewView)} />
         <Route path="proposals/:proposalId" component={requireAuthentication(Proposal)} />
         <Route path="aggregations" component={requireAuthentication(Aggregations)} />
         <Route path="profile"   component={requireAuthentication(Profile)} />

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -1,7 +1,6 @@
 
 
 export function adaptProposalData(proposalData, hour=24) {
-  console.log("entro");
     let result={};
     const aggregationNum = proposalData.result.length;
 


### PR DESCRIPTION
### Release 0.5.0

Provide those functionalities:
- display a summary of a Proposal using Indicators:
  1) The number of CUPS
  2) The total amount of invoices
  3) The % of invoice types by origin (F1, F5D, P5D, ...)
  4) The count of Tariffs
  5) The hourly AVG measures per Tariff
, all of them applying to the current proposal/historical scope.
- isolate the historicals from the future proposals
- tables are formated to ensure
  - values are centered and always are displayed (avoid cut it using ellipsis...)
  - index are right aligned
  - are not rendered if there are too many columns to display (unusable table)
- charts legend are not rendered if there are too many elements to display
  - to priorize the chart itself instead of the legend


#### Detailed changes
- New component \<ProposalDetail>
- New component \<Indicator> to create a tile with
  - title
  - value
  - (optional) icon
  - (optional) percentage (bool) and total value, to render a graphical percentage instead an icon
  - (optional) small to render a small tile
- \<ProposalTableMaterial> now handle the totals prop to activate or not the totals column and rows.
  - Also, if the bckground is black the text is changed to white
- /historics/new render a workflow to create a new historic
- A proposal show their related future and past dates if exist, if it's an historical just show the past dates

#### Fixed issues
- Fix #133 :: Proposal Indicators
- Fix #135 :: Activate historical view
- Fix #137 :: Proposal table content positioning
- Fix #139 :: Show always table content
- Fix #140 :: ProposalGraph avoid showing legend if too many components
- Fix #141 :: ProposalTableMaterial avoid rendering table if too many components


#### Related PR
- #136 :: Proposal Indicators
- #142 :: Historical view