### PR TITLE
Export current proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
       "webpack-hot-middleware": "^2.15.0",
       "webpack-merge": "^2.3.1",
       "yargs": "^6.6.0",
-      "blueimp-md5": "latest"
+      "blueimp-md5": "latest",
+      "file-saver": "latest"
   },
   "dependencies": {}
 }

--- a/src/actions/proposal.js
+++ b/src/actions/proposal.js
@@ -1,4 +1,4 @@
-import { FETCH_PROPOSAL_REQUEST, RUN_PROPOSAL_REQUEST, RECEIVE_PROPOSAL, RECEIVE_RUN_PROPOSAL, RECEIVE_RUN_PROPOSAL_ERROR, FETCH_AGGREGATIONS_REQUEST, RECEIVE_AGGREGATIONS, DUPLICATE_PROPOSAL_REQUEST, DELETE_PROPOSAL_REQUEST, CREATE_PROPOSAL_REQUEST } from '../constants/index'
+import { EXPORT_PROPOSAL_REQUEST, FETCH_PROPOSAL_REQUEST, RUN_PROPOSAL_REQUEST, RECEIVE_PROPOSAL, RECEIVE_RUN_PROPOSAL, RECEIVE_RUN_PROPOSAL_ERROR, FETCH_AGGREGATIONS_REQUEST, RECEIVE_AGGREGATIONS, DUPLICATE_PROPOSAL_REQUEST, DELETE_PROPOSAL_REQUEST, CREATE_PROPOSAL_REQUEST } from '../constants/index'
 import { data_fetch_api_resource, data_create_api_resource, data_delete_api_resource } from '../utils/http_functions'
 import { parseJSON } from '../utils/misc'
 import { logoutAndRedirect, redirectToRoute } from './auth'
@@ -293,6 +293,38 @@ export function fetchAggregations(token) {
             .then(parseJSON)
             .then(response => {
                 dispatch(receiveAggregations(response.result));
+            })
+            .catch(error => {
+                if (error.status === 401) {
+                    dispatch(logoutAndRedirect(error));
+                }
+            });
+    };
+}
+
+
+
+
+
+/*********************
+  #################
+   EXPORT PROPOSAL
+  #################
+*********************/
+
+export function exportProposalRequest() {
+    return {
+        type: EXPORT_PROPOSAL_REQUEST,
+    };
+}
+
+export function exportProposal(token, proposal) {
+    return (dispatch) => {
+        dispatch(exportProposalRequest());
+        data_fetch_api_resource(token, "proposal/" + proposal + "/xls/")
+            .then(response => {
+               FileSaver.saveAs(blob, "asdadasdasd");
+
             })
             .catch(error => {
                 if (error.status === 401) {

--- a/src/actions/proposal.js
+++ b/src/actions/proposal.js
@@ -326,7 +326,8 @@ export function exportProposal(token, proposal) {
         dispatch(exportProposalRequest());
         data_download_api_resource(token, "proposal/" + proposal + "/xls/")
             .then(response => {
-               FileSaver.saveAs(response.data, "response.xls");
+               const filename = response.headers["content-disposition"].split("=");
+               FileSaver.saveAs(response.data, filename[1]);
             })
             .catch(error => {
                 if (error.status === 401) {

--- a/src/actions/proposal.js
+++ b/src/actions/proposal.js
@@ -1,5 +1,5 @@
 import { EXPORT_PROPOSAL_REQUEST, FETCH_PROPOSAL_REQUEST, RUN_PROPOSAL_REQUEST, RECEIVE_PROPOSAL, RECEIVE_RUN_PROPOSAL, RECEIVE_RUN_PROPOSAL_ERROR, FETCH_AGGREGATIONS_REQUEST, RECEIVE_AGGREGATIONS, DUPLICATE_PROPOSAL_REQUEST, DELETE_PROPOSAL_REQUEST, CREATE_PROPOSAL_REQUEST } from '../constants/index'
-import { data_fetch_api_resource, data_create_api_resource, data_delete_api_resource } from '../utils/http_functions'
+import { data_download_api_resource, data_fetch_api_resource, data_create_api_resource, data_delete_api_resource } from '../utils/http_functions'
 import { parseJSON } from '../utils/misc'
 import { logoutAndRedirect, redirectToRoute } from './auth'
 import { fetchProposals } from './proposals'
@@ -312,6 +312,9 @@ export function fetchAggregations(token) {
   #################
 *********************/
 
+
+var FileSaver = require('../../node_modules/file-saver/FileSaver.min.js');
+
 export function exportProposalRequest() {
     return {
         type: EXPORT_PROPOSAL_REQUEST,
@@ -321,10 +324,9 @@ export function exportProposalRequest() {
 export function exportProposal(token, proposal) {
     return (dispatch) => {
         dispatch(exportProposalRequest());
-        data_fetch_api_resource(token, "proposal/" + proposal + "/xls/")
+        data_download_api_resource(token, "proposal/" + proposal + "/xls/")
             .then(response => {
-               FileSaver.saveAs(blob, "asdadasdasd");
-
+               FileSaver.saveAs(response.data, "response.xls");
             })
             .catch(error => {
                 if (error.status === 401) {

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -30,6 +30,7 @@ import DetailIcon from 'material-ui/svg-icons/navigation/expand-more';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import DuplicateIcon from 'material-ui/svg-icons/content/content-copy';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
+import ExportIcon from 'material-ui/svg-icons/file/file-download';
 
 import {adaptProposalData} from '../../utils/graph';
 

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -373,6 +373,20 @@ export class Proposal extends Component {
         this.props.deleteProposal(token, proposalID);
     };
 
+    exportProposal = (event, proposalID) => {
+        event.preventDefault();
+
+        this.setState({
+            animateChart: false,
+            message_text: "Exporting current proposal",
+            confirmation_open: false,
+        });
+
+        const token = this.props.token;
+        this.props.exportProposal(token, proposalID);
+    };
+
+
     handleConfirmation = (what, message, text) => {
         this.next = what;
         this.message = message

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -440,6 +440,7 @@ export class Proposal extends Component {
         const reRunProposal = this.reRunProposalQuestion;
         const duplicateProposal = this.duplicateProposalQuestion;
         const deleteProposal = this.deleteProposalQuestion;
+        const exportProposal=this.exportProposal;
 
         const toggleDetail = this.toggleDetail;
 
@@ -627,6 +628,7 @@ export class Proposal extends Component {
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
                 <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
+                <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
                 <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
                 <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -69,6 +69,8 @@ export const APP_CHANGE_OFFSET = 'APP_CHANGE_OFFSET';
 export const NEW_NOTIFICATION = 'NEW_NOTIFICATION';
 export const NOTIFICATION_DONE = 'NOTIFICATION_DONE';
 
+export const EXPORT_PROPOSAL_REQUEST = 'EXPORT_PROPOSAL_REQUEST';
+
 export const colors = [
     '#db4939',
     '#f29913',

--- a/src/utils/http_functions.js
+++ b/src/utils/http_functions.js
@@ -71,6 +71,10 @@ export function data_fetch_api_resource(token, resource) {
     return axios.get(API_PREFIX + "/" + resource);
 }
 
+export function data_download_api_resource(token, resource) {
+    return axios.get(API_PREFIX + "/" + resource, {responseType: 'blob'});
+}
+
 export function data_create_api_resource(token, resource, new_data) {
     return axios.post(API_PREFIX + "/" + resource, new_data);
 }


### PR DESCRIPTION
### Export current Proposal

Integrates a new button inside the Proposal view named "EXPORT" that ask the API to fetch the related XLS file.

Return an attachment using file-saver lib (there are a lot of lags regarding file downloads using html5, and it's safer to use this lib instead of create a form based hack).

The name of the file is defined from the API

#### Provides 
- The actions (EXPORT_PROPOSAL_REQUEST) needed to fetch the API in an standardized way using tokens
- utils/http_functions new method data_download_api_resource to ask the API forcing a BLOB response.
- \<Proposal> integrates the new button "EXPORT" that trigger the download of the related XLS file

Fix #143 :: Export Proposals

Related to https://github.com/gisce/oraKWlum-api-pub/issues/117 and https://github.com/gisce/oraKWlum-api-pub/pull/118