### PR TITLE
Extend proposal indicators

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -8,7 +8,7 @@ export const Footer = () =>
         <div className="container">
             <div className="row">
                 <div className="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-                    <p>GISCE 2016</p>
+                    <p>GISCE 2017</p>
                 </div>
             </div>
         </div>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -134,7 +134,7 @@ Indicator.propTypes = {
     subvalue: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.number,
-    ]).isRequired,
+    ]),
     percentage: React.PropTypes.bool,
     total: React.PropTypes.number,
     small: React.PropTypes.bool,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -32,8 +32,8 @@ const styles = {
         width: 200,
     },
     smallSize: {
-        height: 200,
-        width: 120,
+        height: 220,
+        width: 150,
     },
     kingSize: {
         height: 300,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -113,7 +113,11 @@ export class Indicator extends Component {
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
                     <span style={styles.value}>{value}</span>
+                    { 
+                        (subvalue != "") && 
+
                     <span style={styles.subvalue}>{subvalue}</span>
+                    }
                     {visual_indicator}
                 </div>
             </Paper>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -116,7 +116,7 @@ export class Indicator extends Component {
                     { 
                         (subvalue != "") && 
 
-                    <span style={styles.subvalue}>{subvalue}</span>
+                    <span style={styles.subvalue}><br/>{subvalue}</span>
                     }
                     {visual_indicator}
                 </div>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -22,10 +22,16 @@ const styles = {
         overflow:'auto',
     },
     header: {
-        fontSize: 22,
+        fontSize: 25,
     },
     value: {
         fontSize: 35,
+    },
+    valueUnit: {
+        fontSize: 20,
+    },
+    subvalue: {
+        fontSize: 20,
     },
     normalSize: {
         height: 200,
@@ -120,7 +126,7 @@ export class Indicator extends Component {
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
 
-                    <span style={styles.value}>{value_list[0]}</span> {value_list[1]}
+                    <span style={styles.value}>{value_list[0]}</span> <span style={styles.valueUnit}>{value_list[1]}</span>
                     { 
                         (subvalue != "" && subvalue != null) && 
 

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -26,7 +26,7 @@ const styles = {
         textDecoration: 'underline',
     },
     value: {
-        fontSize: 30,
+        fontSize: 35,
     },
     valueUnit: {
         fontSize: 20,
@@ -67,8 +67,6 @@ export class Indicator extends Component {
 
         const which_color = (this.props.color)? this.props.color : false;
 
-
-
         const style_color = (which_color)?
             {
                 backgroundColor: which_color,
@@ -89,6 +87,9 @@ export class Indicator extends Component {
         const {title, value, subvalue} = this.props;
         const value_asInt = parseInt(value);
         const subvalue_asInt = parseInt(subvalue);
+
+        const valueInfo = (this.props.valueInfo)?this.props.valueInfo:null;
+        const subvalueInfo = (this.props.subvalueInfo)?this.props.subvalueInfo:null;
 
         const is_percentage = (this.props.percentage)?this.props.percentage:false;
         const total = (this.props.total)?parseInt(this.props.total):0;
@@ -123,13 +124,17 @@ export class Indicator extends Component {
         const has_unit = (value.toString().search(" ")>-1)?true:false;
         const value_list = value.toString().split(" ");
 
+        const hasSubvalue = (subvalue != "" && subvalue != null)
+
+        const separator = (hasSubvalue)?<br/>:null;
+
         return (
             <Paper key={"invoice_"+title} style={paper_style} zDepth={styles.paperDepth}>
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
 
-                    <br/>
-                    <span title={"Amount of energy in " + value_list[1]} style={styles.value}>{value_list[0]}</span> 
+                    {separator}
+                    <span title={valueInfo} style={styles.value}>{value_list[0]}</span> 
                     {
                         (has_unit) &&
                         <span 
@@ -139,17 +144,17 @@ export class Indicator extends Component {
                     }
 
                     { 
-                        (subvalue != "" && subvalue != null) && 
+                        (hasSubvalue) &&
                     <span 
-                        title={"Count of CUPS"}
+                        title={subvalueInfo}
                         style={styles.subvalue}
                     >
                             <br/>{subvalue}
                     </span>
 
                     }
-                    <br/>
-                    <br/>
+                    {separator}
+                    {separator}
                     {visual_indicator}
                 </div>
             </Paper>
@@ -167,6 +172,8 @@ Indicator.propTypes = {
         React.PropTypes.string,
         React.PropTypes.number,
     ]),
+    valueInfo: React.PropTypes.string,
+    subvalueInfo: React.PropTypes.string,
     percentage: React.PropTypes.bool,
     total: React.PropTypes.number,
     small: React.PropTypes.bool,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -129,15 +129,24 @@ export class Indicator extends Component {
                     <h3 style={styles.header}>{title}</h3>
 
                     <br/>
-                    <span style={styles.value}>{value_list[0]}</span> 
+                    <span title={"Amount of energy in " + value_list[1]} style={styles.value}>{value_list[0]}</span> 
                     {
                         (has_unit) &&
-                        <span style={styles.valueUnit}>{value_list[1]}</span>
+                        <span 
+                            style={styles.valueUnit}
+                        >{value_list[1]}
+                        </span>
                     }
 
                     { 
                         (subvalue != "" && subvalue != null) && 
-                    <span style={styles.subvalue}><br/>{subvalue}</span>
+                    <span 
+                        title={"Count of CUPS"}
+                        style={styles.subvalue}
+                    >
+                            <br/>{subvalue}
+                    </span>
+
                     }
                     <br/>
                     <br/>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -75,8 +75,9 @@ export class Indicator extends Component {
             backgroundColor: which_color,
         }, styles.paper);
 
-        const {title, value} = this.props;
+        const {title, value, subvalue} = this.props;
         const value_asInt = parseInt(value);
+        const subvalue_asInt = parseInt(subvalue);
 
         const is_percentage = (this.props.percentage)?this.props.percentage:false;
         const total = (this.props.total)?parseInt(this.props.total):0;
@@ -112,6 +113,7 @@ export class Indicator extends Component {
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
                     <span style={styles.value}>{value}</span>
+                    <span style={styles.subvalue}>{subvalue}</span>
                     {visual_indicator}
                 </div>
             </Paper>
@@ -122,6 +124,10 @@ export class Indicator extends Component {
 Indicator.propTypes = {
     title: React.PropTypes.string.isRequired,
     value: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number,
+    ]).isRequired,
+    subvalue: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.number,
     ]).isRequired,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -114,9 +114,10 @@ export class Indicator extends Component {
                     <h3 style={styles.header}>{title}</h3>
                     <span style={styles.value}>{value}</span>
                     { 
-                        (subvalue != "") && 
+                        (subvalue != "" && subvalue != null) && 
 
                     <span style={styles.subvalue}><br/>{subvalue}</span>
+
                     }
                     {visual_indicator}
                 </div>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -21,11 +21,11 @@ const styles = {
         textAlign: 'center',
         overflow:'auto',
     },
-    value: {
-        fontSize: 35,
-    },
     header: {
         fontSize: 22,
+    },
+    value: {
+        fontSize: 35,
     },
     normalSize: {
         height: 200,
@@ -38,7 +38,11 @@ const styles = {
     kingSize: {
         height: 300,
         width: 300,
-    }
+    },
+    indicatorHeader: {
+        fontSize: 35,
+        fontWeight: 300,
+    },
 };
 
 
@@ -108,11 +112,15 @@ export class Indicator extends Component {
 
             ;
 
+
+        const value_list = value.toString().split(" ");
+
         return (
             <Paper key={"invoice_"+title} style={paper_style} zDepth={styles.paperDepth}>
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
-                    <span style={styles.value}>{value}</span>
+
+                    <span style={styles.value}>{value_list[0]}</span> {value_list[1]}
                     { 
                         (subvalue != "" && subvalue != null) && 
 

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -23,9 +23,10 @@ const styles = {
     },
     header: {
         fontSize: 25,
+        textDecoration: 'underline',
     },
     value: {
-        fontSize: 35,
+        fontSize: 30,
     },
     valueUnit: {
         fontSize: 20,
@@ -38,7 +39,7 @@ const styles = {
         width: 200,
     },
     smallSize: {
-        height: 220,
+        height: 260,
         width: 150,
     },
     kingSize: {
@@ -127,6 +128,7 @@ export class Indicator extends Component {
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
 
+                    <br/>
                     <span style={styles.value}>{value_list[0]}</span> 
                     {
                         (has_unit) &&
@@ -135,10 +137,10 @@ export class Indicator extends Component {
 
                     { 
                         (subvalue != "" && subvalue != null) && 
-
                     <span style={styles.subvalue}><br/>{subvalue}</span>
-
                     }
+                    <br/>
+                    <br/>
                     {visual_indicator}
                 </div>
             </Paper>

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -119,6 +119,7 @@ export class Indicator extends Component {
             ;
 
 
+        const has_unit = (value.toString().search(" ")>-1)?true:false;
         const value_list = value.toString().split(" ");
 
         return (
@@ -126,7 +127,12 @@ export class Indicator extends Component {
                 <div style={{ color: style_color.color }}>
                     <h3 style={styles.header}>{title}</h3>
 
-                    <span style={styles.value}>{value_list[0]}</span> <span style={styles.valueUnit}>{value_list[1]}</span>
+                    <span style={styles.value}>{value_list[0]}</span> 
+                    {
+                        (has_unit) &&
+                        <span style={styles.valueUnit}>{value_list[1]}</span>
+                    }
+
                     { 
                         (subvalue != "" && subvalue != null) && 
 

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -98,7 +98,7 @@ export class Indicator extends Component {
 
         const visual_indicator = (is_percentage) && (total>=0) ?
             (
-                <div style={styles.fixedSize}>
+                <div title={valueInfo} style={styles.fixedSize}>
                     <CircularProgress
                         mode="determinate"
                         value={value_asInt}
@@ -108,7 +108,7 @@ export class Indicator extends Component {
                         color= {style_color.color}
                     />
                     <br/>
-                    {((value_asInt/total)*100).toFixed(1)}%
+                    <span title={valueInfo}>{((value_asInt/total)*100).toFixed(1)}%</span>
                 </div>
             )
             :

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -580,7 +580,7 @@ export class Proposal extends Component {
         const proposalActions =
              (!readOnly)?
               <CardActions>
-                <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
+                <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)} title={"Refresh current proposal"}/>
                 <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)} title={"Reprocess current proposal"}/>
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)} title={"Toggle detailed view"}/>
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -583,7 +583,7 @@ export class Proposal extends Component {
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
                 <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
-                <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)}/>
+                <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
                 <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
                 <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -577,18 +577,36 @@ export class Proposal extends Component {
 
 
 
+        const proposalActions =
+             (!readOnly)?
+              <CardActions>
+                <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
+                <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
+                <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
+                <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)}/>
+                <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
+                <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
+                <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>
+              </CardActions>
+            :
+            none;
+
+
         const proposalDetail = (summary != null) && (detail_open == true) &&
-          <div style={styles.cardSeparator}>
-              <ProposalDetail
-                  data={summary}
-                  avg_info={{
-                      'data': data,
-                      'components': components,
-                  }}
-              />
+		  <div>
+			  {proposalActions}
+			  <div style={styles.cardSeparator}>
+
+				  <ProposalDetail
+					  data={summary}
+					  avg_info={{
+						  'data': data,
+						  'components': components,
+					  }}
+				  />
+			  </div>
           </div>
         ;
-
 
 
         // The resulting Proposal element
@@ -618,23 +636,16 @@ export class Proposal extends Component {
                   <p><span>Last execution was done at {lastExecution}</span></p>
           }
               </CardText>
+	
+			  <br/>
 
-          {proposalPicture}
+			  {proposalPicture}
 
-          {proposalDetail}
+			  <br/>
 
-          {
-              !readOnly &&
-              <CardActions>
-                <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
-                <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
-                <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
-                <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)}/>
-                <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
-                <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
-                <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>
-              </CardActions>
-          }
+			  {proposalDetail}
+
+			  {proposalActions}
 
             </Card>
         );

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -585,7 +585,7 @@ export class Proposal extends Component {
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
-                <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)}/>
+                <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)} title={"Duplicate current proposal to a new one"}/>
                 <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>
               </CardActions>
             :

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -586,7 +586,7 @@ export class Proposal extends Component {
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
                 <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)} title={"Duplicate current proposal to a new one"}/>
-                <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)}/>
+                <FlatButton label="Delete" icon={<DeleteIcon/>} onClick={(e) => deleteProposal(e, proposal.id)} title={"Delete current proposal"}/>
               </CardActions>
             :
             none;

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -26,7 +26,8 @@ import Dialog from 'material-ui/Dialog';
 //Icons
 import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
 import RunIcon from 'material-ui/svg-icons/av/play-circle-outline';
-import DetailIcon from 'material-ui/svg-icons/navigation/expand-more';
+import ExpandIcon from 'material-ui/svg-icons/navigation/expand-more';
+import CollapseIcon from 'material-ui/svg-icons/navigation/expand-less';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import DuplicateIcon from 'material-ui/svg-icons/content/content-copy';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
@@ -413,6 +414,8 @@ export class Proposal extends Component {
         const dayOfProposal = new Date(proposal.days_range[0]).getDay();
         const dayOfProposalFuture = (historical) ? null : new Date(proposal.days_range_future[0]).getDay();
 
+
+
         let daysRange_toShow;
         if (historical == false) {
              daysRange_toShow = new Date(proposal.days_range_future[0]).toLocaleDateString(locale, dateOptions) + " - " + new Date(proposal.days_range_future[1]).toLocaleDateString(locale, dateOptions);
@@ -443,6 +446,8 @@ export class Proposal extends Component {
         const toggleDetail = this.toggleDetail;
 
         const detail_open = this.detail_open;
+
+        const DetailIcon = (detail_open == false)?ExpandIcon:CollapseIcon;
 
         const actionsButtons = [
           <FlatButton

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -582,7 +582,7 @@ export class Proposal extends Component {
               <CardActions>
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
                 <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
-                <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)}/>
+                <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)} title={"Toggle detailed view"}/>
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>
                 <FlatButton label="Duplicate" icon={<DuplicateIcon/>} onClick={(e) => duplicateProposal(e, proposal.id)} title={"Duplicate current proposal to a new one"}/>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -447,7 +447,7 @@ export class Proposal extends Component {
 
         const detail_open = this.detail_open;
 
-        const DetailIcon = (detail_open == false)?ExpandIcon:CollapseIcon;
+        const DetailIcon = (detail_open == true)?CollapseIcon:ExpandIcon;
 
         const actionsButtons = [
           <FlatButton

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -581,7 +581,7 @@ export class Proposal extends Component {
              (!readOnly)?
               <CardActions>
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)} title={"Refresh current proposal"}/>
-                <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)} title={"Reprocess current proposal"}/>
+                <FlatButton label="Reprocess" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)} title={"Reprocess current proposal"}/>
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)} title={"Toggle detailed view"}/>
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -581,7 +581,7 @@ export class Proposal extends Component {
              (!readOnly)?
               <CardActions>
                 <FlatButton label="Refresh" icon={<RefreshIcon/>} onClick={(e) => refreshProposal(e, proposal.id)}/>
-                <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)}/>
+                <FlatButton label="Run" icon={<RunIcon/>} onClick={(e) => reRunProposal(e, proposal.id)} title={"Reprocess current proposal"}/>
                 <FlatButton label="Detail" icon={<DetailIcon/>} onClick={(e) => toggleDetail(e)} title={"Toggle detailed view"}/>
                 <FlatButton label="Export" icon={<ExportIcon/>} onClick={(e) => exportProposal(e, proposal.id)} title={"Export Proposal to a XLS file"}/>
                 <FlatButton label="Edit" icon={<EditIcon/>} disabled/>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -85,8 +85,8 @@ export class ProposalDetail extends Component {
                     <Indicator
                         key={"indicator_"+component_name}
                         title={ (component_name!="")?component_name:"Empty"}
-                        value={component_value}
-                        subvalue={component_subvalue}
+                        value={component_value + " kW"}
+                        subvalue={"#" + component_subvalue}
                         total={total_tariffs_sum}
                         percentage={true}
                         small={true}

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -63,9 +63,9 @@ export class ProposalDetail extends Component {
 
         //handle tariff tiles
         let cups_per_tariff = {};
-        const tariff_count = (data.tariff_count) &&
+        const tariff_count = (data.tariffs) &&
 
-            Object.keys(data.tariff_count).map(function(i) {
+            Object.keys(data.tariffs).map(function(i) {
                 const entry = data.tariff_count[i];
 
                 const component_name = entry['name'];

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -61,7 +61,7 @@ export class ProposalDetail extends Component {
         });
 
 
-        //handle tariff count
+        //handle tariff tiles
         let cups_per_tariff = {};
         const tariff_count = (data.tariff_count) &&
 
@@ -70,6 +70,7 @@ export class ProposalDetail extends Component {
 
                 const component_name = entry['name'];
                 const component_value =  entry['count'];
+                const component_subvalue =  entry['position'];
                 const original_position =  entry['position'];
 
                 const color = colors[original_position];
@@ -81,6 +82,7 @@ export class ProposalDetail extends Component {
                         key={"indicator_"+component_name}
                         title={ (component_name!="")?component_name:"Empty"}
                         value={component_value}
+                        subvalue={component_subvalue}
                         total={data.tariff_total}
                         percentage={true}
                         small={true}

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -153,7 +153,7 @@ export class ProposalDetail extends Component {
                     <br/>
 
                     <div>
-                        <h3>TARIFF COUNT</h3>
+                        <h2>TARIFFS INFO</h2>
                         {tariffs}
                     </div>
 
@@ -161,7 +161,7 @@ export class ProposalDetail extends Component {
                     <br/>
 
                     <div>
-                        <h3>TARIFF AVG</h3>
+                        <h2>TARIFFS AVERAGE</h2>
                         {avg_tariff_table}
                     </div>
 

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -61,6 +61,9 @@ export class ProposalDetail extends Component {
         });
 
 
+        //total tariffs count
+        const total_tariffs_count = data.tariffs_total_count;
+
         //handle tariff tiles
         let cups_per_tariff = {};
         const tariff_count = (data.tariffs) &&
@@ -83,7 +86,7 @@ export class ProposalDetail extends Component {
                         title={ (component_name!="")?component_name:"Empty"}
                         value={component_value}
                         subvalue={component_subvalue}
-                        total={data.tariff_total}
+                        total={total_tariffs_count}
                         percentage={true}
                         small={true}
                         color={color}

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -62,14 +62,14 @@ export class ProposalDetail extends Component {
 
 
         //total tariffs count
-        const total_tariffs_count = data.tariffs_total_count;
+        const total_tariffs_count = data.tariff_total_count;
 
         //handle tariff tiles
         let cups_per_tariff = {};
-        const tariff_count = (data.tariffs) &&
+        const tariffs = (data.tariffs) &&
 
             Object.keys(data.tariffs).map(function(i) {
-                const entry = data.tariff_count[i];
+                const entry = data.tariffs[i];
 
                 const component_name = entry['name'];
                 const component_value =  entry['energy'];
@@ -135,7 +135,7 @@ export class ProposalDetail extends Component {
             table_data[hora] = una_hora;
         }
 
-        const avg_tariff_table = (data.tariff_count) &&
+        const avg_tariff_table = (data.tariffs) &&
             <ProposalTableMaterial stacked={true} data={table_data} components={avg_info.components} height={500} totals={false}/>
 
 
@@ -153,7 +153,7 @@ export class ProposalDetail extends Component {
 
                     <div>
                         <h3>TARIFF COUNT</h3>
-                        {tariff_count}
+                        {tariffs}
                     </div>
 
                     <br/>

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -69,8 +69,8 @@ export class ProposalDetail extends Component {
                 const entry = data.tariff_count[i];
 
                 const component_name = entry['name'];
-                const component_value =  entry['count'];
-                const component_subvalue =  entry['position'];
+                const component_value =  entry['energy'];
+                const component_subvalue =  entry['count'];
                 const original_position =  entry['position'];
 
                 const color = colors[original_position];

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -63,6 +63,7 @@ export class ProposalDetail extends Component {
 
         //total tariffs count
         const total_tariffs_count = data.tariff_total_count;
+        const total_tariffs_sum = data.measures_total;
 
         //handle tariff tiles
         let cups_per_tariff = {};
@@ -78,7 +79,7 @@ export class ProposalDetail extends Component {
 
                 const color = colors[original_position];
 
-                cups_per_tariff[component_name] = component_value;
+                cups_per_tariff[component_name] = component_subvalue;
 
                 return (
                     <Indicator
@@ -86,7 +87,7 @@ export class ProposalDetail extends Component {
                         title={ (component_name!="")?component_name:"Empty"}
                         value={component_value}
                         subvalue={component_subvalue}
-                        total={total_tariffs_count}
+                        total={total_tariffs_sum}
                         percentage={true}
                         small={true}
                         color={color}

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -114,6 +114,8 @@ export class ProposalDetail extends Component {
                     title="Invoices"
                     value={data.invoice_total}
                     icon={<InvoicesIcon style={styles.icon}/>}
+                    valueInfo="Amount of energy in kW"
+                    subvalueInfo="Count of CUPS"
                 />
             );
 

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -58,11 +58,11 @@ export class ProposalTableMaterial extends Component {
                 <div>
                     <br/>
                     <p>
-                        Sorry, but <strong>there too many components</strong> to render using this aggregation, and the <strong>table will be un-usable</strong>.
+                        Sorry, but <strong>there are too many components to render</strong> using this aggregation, the <strong>table will be un-usable</strong>.
                     </p>
 
                     <p>
-                        Change to chart view or select another aggregation to review their related table.
+                        Export the Proposal to a spreadsheet, toggle to chart view or select another aggregation to view their table.
                     </p>
                     <br/>
                 </div>


### PR DESCRIPTION
### Extend Proposal indicators

Proposal indicators are improved to reach:
- [x] energy (kW)
- [x] count of CUPS
- [x] pie chart of the amount of energy

#### Detailed changes

\<ProposalDetail/> now:
- Shows
  - Tariffs info:
    - For each tariff, render:
      - Total amount of energy (in kW)
      - Related count of CUPS
      - A visual chart showing the related % of energy (tariff energy vs total energy)
   - Tariffs average still showing the avg of energy per tariff and hour
- \<ProposalActions> are included to this view to provide an enhanced user experience (duplicated actions, following the chart and at the end of the Detailed view).
  - Detail icon is modified to handle the current status (collapsed / expanded)
  - RUN button is called now REPROCESS 

An \<Indicator> is re-formatted:
- Value reach high priority and can contain an unit (passed as a prop value="VALUE unit") 
- Subvalue is re-positioned to reach visual coherence
- Titles are included for each component to be more comprehensive

Additionally:
- Footer year is updated 2016 -> 2017 

#### Fixed issues
- Fix #148 :: Extend Proposal indicators