### PR TITLE
Fix units to kWh

### DIFF
--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -40,7 +40,7 @@ const styles = {
     },
     smallSize: {
         height: 260,
-        width: 150,
+        width: 180,
     },
     kingSize: {
         height: 300,

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -29,6 +29,7 @@ const styles = {
         fontSize: 35,
     },
     valueUnit: {
+        marginLeft: 4,
         fontSize: 20,
     },
     subvalue: {

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -569,9 +569,9 @@ export class Proposal extends Component {
                 (proposal.prediction) &&
                   (
                       (proposalTable)?
-                          <ProposalTableMaterial stacked={true} data={data} components={components} height={500} />
+                          <ProposalTableMaterial stacked={true} data={data} components={components} height={500} unit={"kWh"}/>
                           :
-                          <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.animateChart} />
+                          <ProposalGraph stacked={true} data={data} components={components} height={500} animated={this.animateChart} unit={"kWh"}/>
                   )
                   :null;
 

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -139,7 +139,7 @@ export class ProposalDetail extends Component {
         }
 
         const avg_tariff_table = (data.tariffs) &&
-            <ProposalTableMaterial stacked={true} data={table_data} components={avg_info.components} height={500} totals={false}/>
+            <ProposalTableMaterial stacked={true} data={table_data} components={avg_info.components} height={500} totals={false} unit={"kWh"}/>
 
 
         return (

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -85,7 +85,7 @@ export class ProposalDetail extends Component {
                     <Indicator
                         key={"indicator_"+component_name}
                         title={ (component_name!="")?component_name:"Empty"}
-                        value={component_value + " kW"}
+                        value={component_value + " kWh"}
                         subvalue={"#" + component_subvalue}
                         total={total_tariffs_sum}
                         percentage={true}

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -111,7 +111,7 @@ export class ProposalGraph extends Component {
             });
             //*/
 
-            const unit = "kWh";
+            const unit = (typeof this.props.unit != 'undefined')?this.props.unit:"kWh";
 
             if (isAreaChart) {
               const areas = Object.keys(components).map(function(component, i) {
@@ -239,4 +239,5 @@ ProposalGraph.propTypes = {
     animated: React.PropTypes.bool,
     width: React.PropTypes.number,
     height: React.PropTypes.number,
+    unit: React.PropTypes.string,
 };

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -111,7 +111,7 @@ export class ProposalGraph extends Component {
             });
             //*/
 
-            const unit = "kW";
+            const unit = "kWh";
 
             if (isAreaChart) {
               const areas = Object.keys(components).map(function(component, i) {

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -32,6 +32,10 @@ const styles = {
     },
     hourColumn: {
     },
+    disclamer:{
+        textAlign: 'center',
+        margin: 5,
+    }
 };
 
 
@@ -50,6 +54,7 @@ export class ProposalTableMaterial extends Component {
         //Add totals by default
         const totals = (typeof this.props.totals !== 'undefined')?this.props.totals:true;
 
+        const disclamer = (typeof this.props.unit != 'undefined' && this.props.unit != null)?<div style={styles.disclamer}><span>*All entries in this table are in {this.props.unit}.</span></div>:null;
 
         const howManyComponents = Object.keys(components).length;
 
@@ -220,6 +225,7 @@ export class ProposalTableMaterial extends Component {
                         {rows}
                     </TableBody>
                 </Table>
+                {disclamer}
             </div>
         );
     }
@@ -231,4 +237,5 @@ ProposalTableMaterial.propTypes = {
     colors: React.PropTypes.object,
     type: React.PropTypes.bool,
     totals: React.PropTypes.bool,
+    unit: React.PropTypes.string,
 };


### PR DESCRIPTION
### All units are setted to kWh!

Also, a disclaimer has been integrated at the end of any data table to show the related unity.

#### Detailed changes
- \<Proposal> use kWh as a unit!
- \<ProposalDetail> use kWh as a unit!
- \<ProposalGraph> now use and accepts the new prop "unit". It's used for the legend
- \<ProposalTableMaterial/> use and accepts the new prop "unit". If provided, a disclaimer is appended at the end of the component to show the related unit.
- \<Indicator>
  - Small box size has been grown to ensure that all elements fit as expected
  - Add some margin between the value and their unit


Fix #151 :: Set all units to kWh