### PR TITLE
Handle debug GET param

### DIFF
--- a/src/constants/debug.js
+++ b/src/constants/debug.js
@@ -1,1 +1,1 @@
-export const debug = true;
+export const debug = false;

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -4,10 +4,20 @@ import React from 'react';
 import { DEBUG } from '../constants';
 
 export function debug(what) {
-    var debug = DEBUG;
+    console.log(window.location.search);
+
+    const params = window.location.search.substring(1).split("&")
+
+    let matched = false;
+    for (let i=0; i<params.length; i++) {
+        if (params[i] == "debug")
+            matched = true;
+    }
+
+    const activate_debug = matched || DEBUG;
 
     return (
-        debug &&
+        activate_debug &&
         <div>
             <h3>Debug:</h3>
             <pre>{ JSON.stringify(what, null, 2) }</pre>


### PR DESCRIPTION
Disable by default debug and activate a method to review if debug query
param (GET param) exist

It works as a flag, if present, DEBUG is activated.

Fix #138 :: Override default DEBUG value