### PR TITLE
Element creation selecting sources

### DIFF
--- a/src/actions/proposal.js
+++ b/src/actions/proposal.js
@@ -1,4 +1,4 @@
-import { EXPORT_PROPOSAL_REQUEST, FETCH_PROPOSAL_REQUEST, RUN_PROPOSAL_REQUEST, RECEIVE_PROPOSAL, RECEIVE_RUN_PROPOSAL, RECEIVE_RUN_PROPOSAL_ERROR, FETCH_AGGREGATIONS_REQUEST, RECEIVE_AGGREGATIONS, DUPLICATE_PROPOSAL_REQUEST, DELETE_PROPOSAL_REQUEST, CREATE_PROPOSAL_REQUEST } from '../constants/index'
+import { EXPORT_PROPOSAL_REQUEST, FETCH_PROPOSAL_REQUEST, RUN_PROPOSAL_REQUEST, RECEIVE_PROPOSAL, RECEIVE_RUN_PROPOSAL, RECEIVE_RUN_PROPOSAL_ERROR, FETCH_AGGREGATIONS_REQUEST, RECEIVE_AGGREGATIONS, DUPLICATE_PROPOSAL_REQUEST, DELETE_PROPOSAL_REQUEST, CREATE_PROPOSAL_REQUEST, FETCH_SETTINGS_REQUEST, RECEIVE_SETTINGS } from '../constants/index'
 import { data_download_api_resource, data_fetch_api_resource, data_create_api_resource, data_delete_api_resource } from '../utils/http_functions'
 import { parseJSON } from '../utils/misc'
 import { logoutAndRedirect, redirectToRoute } from './auth'
@@ -240,7 +240,7 @@ export function deleteProposal(token, proposal) {
                     dispatch(redirectToRoute("/proposals"));
                 }
                 else {
-                    console.log("ERROR:" + response.result.message);
+                    console.error("ERROR:" + response.result.message);
                 }
             })
             .catch(error => {
@@ -294,13 +294,52 @@ export function fetchAggregations(token) {
 
 
 
+/**********************
+  ###################
+   FETCH SOURCES triggering Settings REDUCER
+  ###################
++**********************/
+
+export function fetchSourcesRequest() {
+    return {
+        type: FETCH_SETTINGS_REQUEST,
+    };
+}
+
+export function receiveSources(data) {
+    return {
+        type: RECEIVE_SETTINGS,
+        payload: {
+            data,
+        },
+    };
+}
+
+export function fetchSources(token) {
+    return (dispatch) => {
+        dispatch(fetchSourcesRequest());
+        data_fetch_api_resource(token, "sources/")
+            .then(parseJSON)
+            .then(response => {
+                dispatch(receiveSources(response.result));
+            })
+            .catch(error => {
+                if (error.status === 401) {
+                    dispatch(logoutAndRedirect(error));
+                }
+            });
+    };
+}
+
+
+
+
 
 /*********************
   #################
    EXPORT PROPOSAL
   #################
 *********************/
-
 
 var FileSaver = require('../../node_modules/file-saver/FileSaver.min.js');
 

--- a/src/components/HistoryNewView.js
+++ b/src/components/HistoryNewView.js
@@ -10,6 +10,7 @@ import { ProposalDefinition } from './ProposalDefinition';
 function mapStateToProps(state) {
     return {
         aggregations: state.proposal.aggregations_list,
+        settings: state.settings,
         token: state.auth.token,
     };
 }
@@ -21,24 +22,31 @@ function mapDispatchToProps(dispatch) {
 @connect(mapStateToProps, mapDispatchToProps)
 export default class HistoryNewView extends React.Component {
     componentWillMount() {
-        this.fetchAggregations();
+        const token = this.props.token;
+        this.fetchSources(token);
+        this.fetchAggregations(token);
     }
 
-    fetchAggregations() {
-        const token = this.props.token;
+    fetchAggregations(token) {
         this.props.fetchAggregations(token);
+    }
+
+    fetchSources(token) {
+        this.props.fetchSources(token);
     }
 
     render() {
         return (
             <div>
-
                 <div>
-
                     <h1>New historic</h1>
 
-                    {this.props.aggregations &&
-                        <ProposalDefinition aggregationsList={this.props.aggregations} type="historic"/>
+                    {this.props.aggregations && this.props.settings.loaded &&
+                        <ProposalDefinition
+                            aggregationsList={this.props.aggregations}
+                            sourcesList={this.props.settings.data.measures}
+                            type="historic"
+                        />
                     }
                 </div>
 

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -172,7 +172,7 @@ export class ProposalDefinition extends Component {
     componentDidMount = () => {
         //override the readyToNext=true setted indirectly by componentWillMount
         this.setState({
-            readyToNext: false,
+            readyToNext: true,
         });
     }
 

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -106,16 +106,18 @@ export class ProposalDefinition extends Component {
           aggregations_list.push( false );
       });
 
-
       let sources_list=[];
-        const measures = props.sourcesList;
-        //initialize sources list
-        measures.map(function(source, i){
-            sources_list.push( false );
-        });
+      let sources_all=[];
+      let measures = [];
+      //initialize sources list
+      props.sourcesList.map(function(source, i){
+          if (source.active) {
+              sources_all.push( source );
+              sources_list.push( false );
+          }
+      });
 
       const element_type = (props.type)?props.type:"proposal";
-
       const minDate = new Date();
 
       let createMethod = props.createProposal;
@@ -141,7 +143,7 @@ export class ProposalDefinition extends Component {
           aggregations_all: props.aggregationsList,
 
           sources: sources_list,
-          sources_all: props.sourcesList,
+          sources_all: sources_all,
 
           name_validation: false,
           name_error_text: null,

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import { SettingsSources } from '../SettingsSources'
+
 import TextField from 'material-ui/TextField';
 import {
   Step,
@@ -62,6 +64,12 @@ const validations = {
         allowEmpty: false,
         required: true,
     },
+    sources: {
+        description: 'Sources of the New Proposal',
+        type: 'array',
+        allowEmpty: false,
+        required: true,
+    },
 }
 
 const types = {
@@ -78,6 +86,7 @@ const types = {
 function mapStateToProps(state) {
     return {
         token: state.auth.token,
+        static_data: state.settings.static_data,
     };
 }
 
@@ -92,10 +101,18 @@ export class ProposalDefinition extends Component {
 
       let aggregations_list=[];
 
-      //initialize list
+      //initialize aggregations list
       props.aggregationsList.map(function(agg, i){
           aggregations_list.push( false );
       });
+
+
+      let sources_list=[];
+        const measures = props.sourcesList;
+        //initialize sources list
+        measures.map(function(source, i){
+            sources_list.push( false );
+        });
 
       const element_type = (props.type)?props.type:"proposal";
 
@@ -119,8 +136,13 @@ export class ProposalDefinition extends Component {
           name: "",
           date_start: minDate,
           date_end: null,
+
           aggregations: aggregations_list,
           aggregations_all: props.aggregationsList,
+
+          sources: sources_list,
+          sources_all: props.sourcesList,
+
           name_validation: false,
           name_error_text: null,
           date_start_validation: false,
@@ -129,16 +151,19 @@ export class ProposalDefinition extends Component {
           date_end_error_text: null,
           aggregations_validation: false,
           aggregations_error_text: null,
+          sources_validation: false,
+          sources_error_text: null,
+
           readyToNext: false,
       };
 
       this.stepsLength = this.getSteps().length;
-      console.log(this.state.type);
     }
 
 
     componentWillMount = () => {
         //select all by default
+        this.handleSources("all");
         this.handleAggregations("all");
     }
 
@@ -164,10 +189,24 @@ export class ProposalDefinition extends Component {
             );
         }
 
+        const sourcesList = this.state.sources_all;
+
+        let sourcesWithStatus = [];
+        for (var i=0; i<sourcesList.length; i++) {
+            let source = sourcesList[i];
+
+            sourcesWithStatus.push(
+                {
+                    name:source.name,
+                    selected:this.state.sources[i],
+                }
+            );
+        }
 
         const proposalSummary = {
             name:this.state.name,
             aggregations:this.state.aggregationsNames,
+            sources:this.state.sourcesNames,
             isNew: true,
             days_range: [
                 this.state.date_start,
@@ -238,6 +277,7 @@ export class ProposalDefinition extends Component {
                     <div>
                         <p>Great! Now <b>select the aggregations</b> to perform:</p>
                         <Table
+                            key={"aggregations_table"}
                             fixedHeader={true}
                             selectable={true}
                             multiSelectable={true}
@@ -286,8 +326,68 @@ export class ProposalDefinition extends Component {
                     </div>
                 )
             },
+
             {
                 key: "3",
+                title: "Sources",
+                content: (
+                    <div>
+                        <p>Finally <b>select the origins</b> to analyze:</p>
+
+                            <Table
+                                key={"sources_table"}
+                                fixedHeader={true}
+                                selectable={true}
+                                multiSelectable={true}
+                                onRowSelection={this.handleSources}
+                            >
+                                <TableHeader
+                                    displaySelectAll={false}
+                                    enableSelectAll={false}
+                                >
+                                  <TableRow>
+                                    <TableHeaderColumn>Name</TableHeaderColumn>
+                                  </TableRow>
+                                </TableHeader>
+
+                                <TableBody
+                                    stripedRows={false}
+                                    deselectOnClickaway={false}
+                                >
+                            {
+                                sourcesWithStatus.map(function(source, index) {
+                                    return (
+                                        <TableRow key={"tableRow_sources"+index} selected={source.selected}>
+                                          <TableRowColumn>{source.name}</TableRowColumn>
+                                        </TableRow>
+                                    )
+                                })
+                            }
+                                </TableBody>
+                            </Table>
+
+                        {
+                                this.state.sources_error_text &&
+                                <div>
+                                    <TextField
+                                        id="sourceError"
+                                        style={{marginTop: 0}}
+                                        floatingLabelText=""
+                                        value=""
+                                        errorText={this.state.sources_error_text}
+                                    />
+                                    <br/>
+                                    <br/>
+                                </div>
+                        }
+
+
+                    </div>
+                )
+            },
+
+            {
+                key: "4",
                 title: "Confirmation",
                 content: (
                     <div>
@@ -318,7 +418,9 @@ export class ProposalDefinition extends Component {
         const state_error_text = field_name + "_error_text";
         const state_validation = field_name + "_validation";
 
+
         if (field === '' || field.length == 0 || !field) {
+
             this.setState({
                 [state_error_text]: null,
                 [state_validation]: false,
@@ -491,6 +593,74 @@ export class ProposalDefinition extends Component {
         }
     }
 
+
+
+    handleSources = (selectedRowsSources) => {
+        let sources_list = [];
+        let sources_selected = [];
+        const sourcesAll = this.props.sourcesList;
+
+        //initialize list with all deselected
+        sourcesAll.map(function(agg, i){
+            sources_list.push( false );
+        });
+
+        if (selectedRowsSources == "all") {
+            //mark all as selected
+            sourcesAll.map(function(agg, i){
+                sources_list[i] =  true;
+                sources_selected.push(i);
+            });
+            selectedRowsSources = sources_list;
+        }
+        else {
+            if (selectedRowsSources != "none")
+                //mark the selected ones
+                selectedRowsSources.map(function(agg, i){
+                    sources_list[agg] = true;
+                    sources_selected.push(agg);
+                });
+        }
+
+        //Extract names to facilitate render of the summary
+        let sourcesNames = [];
+        sourcesAll.map( (agg,i) => {
+            sources_list[i] && sourcesNames.push(agg);
+        });
+
+        this.setState({
+            sources: sources_list,
+            sourcesNames: sourcesNames,
+            sourcesSelectedRows: sources_selected,
+        });
+
+        const basicValidation = this.validateField({sources: sources_list}, "sources_list", { properties: { sources: validations.sources} } );
+
+        if (basicValidation) {
+            // review that at least, one element is selected
+            let anySelected = false;
+            sources_list.map( (agg, i) => {
+                    if (agg) anySelected=true;
+                }
+            );
+
+            if (!anySelected) {
+                this.setState({
+                    sources_error_text: "Select at least one source",
+                    sources_validation: false,
+                    readyToNext: false,
+                });
+            }
+            else {
+                this.setState({
+                    sources_error_text: null,
+                    sources_validation: true,
+                    readyToNext: true,
+                });
+            }
+        }
+    }
+
     // auxiliar method responsible of validate the next step (for x -> prev -> next flows)
     validateNext = (index) => {
         let x = event;
@@ -508,6 +678,9 @@ export class ProposalDefinition extends Component {
 
             case 2:
                 this.handleAggregations(this.state.aggregationsSelectedRows);
+                break;
+            case 3:
+                this.handleSources(this.state.sourcesSelectedRows);
                 break;
         }
     }
@@ -605,7 +778,7 @@ export class ProposalDefinition extends Component {
     }
 
     createNewProposal (event) {
-        console.log("create");
+        console.debug("Creating new Element");
         const token = this.props.token;
 
         //Ensure 00:00:00 of each day
@@ -618,6 +791,7 @@ export class ProposalDefinition extends Component {
         const proposalData = {
             name:this.state.name,
             aggregations:this.state.aggregationsNames,
+            sources:this.state.sourcesNames,
             isNew: true,
             days_range: [
                 date_start,
@@ -630,7 +804,7 @@ export class ProposalDefinition extends Component {
             },
         }
 
-
+        console.debug("data", proposalData);
         this.state.createMethod(token, proposalData);
     }
 

--- a/src/components/ProposalNewView.js
+++ b/src/components/ProposalNewView.js
@@ -10,6 +10,7 @@ import { ProposalDefinition } from './ProposalDefinition';
 function mapStateToProps(state) {
     return {
         aggregations: state.proposal.aggregations_list,
+        settings: state.settings,
         token: state.auth.token,
     };
 }
@@ -21,24 +22,30 @@ function mapDispatchToProps(dispatch) {
 @connect(mapStateToProps, mapDispatchToProps)
 export default class ProfileView extends React.Component {
     componentWillMount() {
-        this.fetchAggregations();
+        const token = this.props.token;
+        this.fetchSources(token);
+        this.fetchAggregations(token);
     }
 
-    fetchAggregations() {
-        const token = this.props.token;
+    fetchAggregations(token) {
         this.props.fetchAggregations(token);
+    }
+
+    fetchSources(token) {
+        this.props.fetchSources(token);
     }
 
     render() {
         return (
             <div>
-
                 <div>
-
                     <h1>New proposal</h1>
 
-                    {this.props.aggregations &&
-                        <ProposalDefinition aggregationsList={this.props.aggregations}/>
+                    {this.props.aggregations && this.props.settings.loaded &&
+                        <ProposalDefinition
+                            aggregationsList={this.props.aggregations}
+                            sourcesList={this.props.settings.data.measures}
+                        />
                     }
                 </div>
 

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -1,82 +1,127 @@
-import React, { Component } from 'react'
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import * as actionCreators from '../../actions/settings';
 
 import { SmartTable } from '../SmartTable'
 
 const styles = {
 };
 
-export class SettingsSources extends Component {
+function mapStateToProps(state) {
+    return {
+        settings: state.settings,
+        token: state.auth.token,
+        loaded: state.settings.loaded,
+        isFetching: state.settings.isFetching,
+        error: state.settings.error,
+        errorMessage: state.settings.data,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return bindActionCreators(actionCreators, dispatch);
+}
+
+@connect(mapStateToProps, mapDispatchToProps)
+export class SettingsSources extends React.Component {
+    componentDidMount() {
+        this.props.reload &&
+            this.fetchData();
+    }
+
+    fetchData() {
+        const token = this.props.token;
+        this.props.fetchSettings(token);
+    }
+
+    updateData(data) {
+        const token = this.props.token;
+        this.props.updateSettings(token, data);
+    }
 
     render() {
-        const {measures, static_data} = this.props;
+        if (this.props.loaded) {
 
-        //Adapt measures
-        const measures_adapted = measures.map(function( entry, index){
-            const active = (entry.active)?"Active":"Deactivated";
-            const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
-            return (
-                [
-                    entry.name,
-                    entry.alias,
-                    entry.type,
-                    entry.unit,
-                    db_fields,
-                    active,
-                ]
+            const {measures, static_data} = (this.props.reload)?
+                 this.props.settings.data
+                 :
+                 this.props;
+
+            //Adapt measures
+            const measures_adapted = measures.map(function( entry, index){
+                const active = (entry.active)?"Active":"Deactivated";
+                const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
+                return (
+                    [
+                        entry.name,
+                        entry.alias,
+                        entry.type,
+                        entry.unit,
+                        db_fields,
+                        active,
+                    ]
+                )
+            })
+
+            //Adapt static data
+            const static_data_adapted = static_data.map(function( entry, index){
+                const active = (entry.active)?"Active":"Deactivated";
+                const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
+                return (
+                    [
+                        entry.name,
+                        entry.alias,
+                        entry.type,
+                        entry.unit,
+                        db_fields,
+                        active,
+                    ]
+                )
+            })
+
+            const headers = [
+                {
+                    title: 'Name',
+                    width: null,
+                },                {
+                    title: 'Alias',
+                    width: null,
+                },                {
+                    title: 'Type',
+                    width: '10%',
+                },                {
+                    title: 'Unit',
+                    width: '10%',
+                },                {
+                    title: 'DB',
+                    width: '30%',
+                },                {
+                    title: 'Status',
+                    width: null,
+                },
+            ];
+
+            const Settings = (this.props.lite)?
+            <SmartTable header={headers} data={measures_adapted}/>
+            :
+            (
+                <div>
+                    <h2>Available sources</h2>
+                    <SmartTable title="Measures" header={headers} data={measures_adapted}/>
+                    <SmartTable title="Static Data" header={headers} data={static_data_adapted}/>
+                </div>
             )
-        })
-
-        //Adapt static data
-        const static_data_adapted = static_data.map(function( entry, index){
-            const active = (entry.active)?"Active":"Deactivated";
-            const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
-            return (
-                [
-                    entry.name,
-                    entry.alias,
-                    entry.type,
-                    entry.unit,
-                    db_fields,
-                    active,
-                ]
-            )
-        })
-
-        const headers = [
-            {
-                title: 'Name',
-                width: null,
-            },                {
-                title: 'Alias',
-                width: null,
-            },                {
-                title: 'Type',
-                width: '10%',
-            },                {
-                title: 'Unit',
-                width: '10%',
-            },                {
-                title: 'DB',
-                width: '30%',
-            },                {
-                title: 'Status',
-                width: null,
-            },
-        ];
-
-        const Settings=(
-            <div>
-                <h2>Available sources</h2>
-                <SmartTable title="Measures" header={headers} data={measures_adapted}/>
-                <SmartTable title="Static Data" header={headers} data={static_data_adapted}/>
-            </div>
-        )
-
-        return Settings;
+            return Settings;
+        }
+        return null;
     }
 }
 
 SettingsSources.propTypes = {
-    measures: React.PropTypes.array.isRequired,
-    static_data: React.PropTypes.array.isRequired,
+    measures: React.PropTypes.array,
+    static_data: React.PropTypes.array,
+    reload: React.PropTypes.bool,
+    lite: React.PropTypes.bool,
 };

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react'
+
+import { SmartTable } from '../SmartTable'
+
+const styles = {
+};
+
+export class SettingsSources extends Component {
+
+    render() {
+        const {measures, static_data} = this.props;
+
+        //Adapt measures
+        const measures_adapted = measures.map(function( entry, index){
+            const active = (entry.active)?"Active":"Deactivated";
+            const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
+            return (
+                [
+                    entry.name,
+                    entry.alias,
+                    entry.type,
+                    entry.unit,
+                    db_fields,
+                    active,
+                ]
+            )
+        })
+
+        //Adapt static data
+        const static_data_adapted = static_data.map(function( entry, index){
+            const active = (entry.active)?"Active":"Deactivated";
+            const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
+            return (
+                [
+                    entry.name,
+                    entry.alias,
+                    entry.type,
+                    entry.unit,
+                    db_fields,
+                    active,
+                ]
+            )
+        })
+
+        const headers = [
+            {
+                title: 'Name',
+                width: null,
+            },                {
+                title: 'Alias',
+                width: null,
+            },                {
+                title: 'Type',
+                width: '10%',
+            },                {
+                title: 'Unit',
+                width: '10%',
+            },                {
+                title: 'DB',
+                width: '30%',
+            },                {
+                title: 'Status',
+                width: null,
+            },
+        ];
+
+        const Settings=(
+            <div>
+                <h2>Available sources</h2>
+                <SmartTable title="Measures" header={headers} data={measures_adapted}/>
+                <SmartTable title="Static Data" header={headers} data={static_data_adapted}/>
+            </div>
+        )
+
+        return Settings;
+    }
+}
+
+SettingsSources.propTypes = {
+    measures: React.PropTypes.array.isRequired,
+    static_data: React.PropTypes.array.isRequired,
+};

--- a/src/components/SettingsView.js
+++ b/src/components/SettingsView.js
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/settings';
 
-
-import { SmartTable } from './SmartTable'
+import { SettingsSources } from './SettingsSources'
 
 import { debug } from '../utils/debug';
 
@@ -43,73 +42,10 @@ export default class SettingsView extends React.Component {
 
         const data = this.props.settings.data;
 
-
         let Settings;
         if (this.props.loaded && data) {
             const {measures, static_data} = data;
-
-            //Adapt measures
-            const measures_adapted = measures.map(function( entry, index){
-                const active = (entry.active)?"Active":"Deactivated";
-                const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
-                return (
-                    [
-                        entry.name,
-                        entry.alias,
-                        entry.type,
-                        entry.unit,
-                        db_fields,
-                        active,
-                    ]
-                )
-            })
-
-
-            //Adapt static data
-            const static_data_adapted = static_data.map(function( entry, index){
-                const active = (entry.active)?"Active":"Deactivated";
-                const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
-                return (
-                    [
-                        entry.name,
-                        entry.alias,
-                        entry.type,
-                        entry.unit,
-                        db_fields,
-                        active,
-                    ]
-                )
-            })
-
-            const headers = [
-                {
-                    title: 'Name',
-                    width: null,
-                },                {
-                    title: 'Alias',
-                    width: null,
-                },                {
-                    title: 'Type',
-                    width: '10%',
-                },                {
-                    title: 'Unit',
-                    width: '10%',
-                },                {
-                    title: 'DB',
-                    width: '30%',
-                },                {
-                    title: 'Status',
-                    width: null,
-                },
-            ];
-
-            Settings=(
-                <div>
-                    <h2>Available sources</h2>
-                    <SmartTable title="Measures" header={headers} data={measures_adapted}/>
-                    <SmartTable title="Static Data" header={headers} data={static_data_adapted}/>
-                </div>
-            )
+            Settings=<SettingsSources measures={measures} static_data={static_data}/>
         } else {
             Settings=null;
         }


### PR DESCRIPTION
### Select sources at element creation

New element assistant now ask the user about the desired sources to review.

#### Detailed changes
* \<SettingSources> now can refetch data and render in lite mode:
  * reload -> avoids the passed measures and static_data and trigger the
 Settings action to refetch sources
  * lite -> render just the measures SmartTable
* Proposal actions have a method to fetch sources from API saving it using the Settings reducer
  * actions.proposals.fetchSources(token)
* \<ProposalDefinition> now have a new step to select the desired sources!
* New Proposal and New Historical views now prefetch the settings.sources data

Fix #181 :: Select desired sources in Element definition

Related to https://trello.com/c/ktPZlX6y/57-activar-i-configurar-diferents-origents-fonts-de-dades-per-cada-organitzacio