### PR TITLE
Source status toggle

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -82,9 +82,10 @@ export function updateSettings(token, data) {
         data_update_api_resource(token, "sources/", data )
             .then(parseJSON)
             .then(response => {
-                if (response.result.was_updated)
+                if (response.result.was_updated) {
                     dispatch(receiveUpdateSettings(response.result));
-                else
+                }
+                else {
                     throw new Error("Error updating Settings");
                     dispatch(receiveUpdateSettingsKO({
                         response: {
@@ -93,6 +94,7 @@ export function updateSettings(token, data) {
                             statusType: "warning",
                         },
                     }));
+                }
 
             })
             .catch(error => {
@@ -109,10 +111,10 @@ export function toggleSourceSettings(token, data) {
         data_update_api_resource(token, "sources/status/toggle", data )
             .then(parseJSON)
             .then(response => {
-                if (response.result.was_updated)
+                if (response.result.was_updated == true)
                     dispatch(receiveUpdateSettings(response.result));
-                else
-                    throw new Error("Error updating Settings");
+                else {
+                    throw new Error("Error toggling Settings");
                     dispatch(receiveUpdateSettingsKO({
                         response: {
                             status: 403,
@@ -120,6 +122,7 @@ export function toggleSourceSettings(token, data) {
                             statusType: "warning",
                         },
                     }));
+                }
 
             })
             .catch(error => {

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -102,3 +102,30 @@ export function updateSettings(token, data) {
             });
     };
 }
+
+export function toggleSourceSettings(token, data) {
+    return (dispatch) => {
+        dispatch(updateSettingsRequest());
+        data_update_api_resource(token, "sources/status/toggle", data )
+            .then(parseJSON)
+            .then(response => {
+                if (response.result.was_updated)
+                    dispatch(receiveUpdateSettings(response.result));
+                else
+                    throw new Error("Error updating Settings");
+                    dispatch(receiveUpdateSettingsKO({
+                        response: {
+                            status: 403,
+                            statusText: 'Invalid token',
+                            statusType: "warning",
+                        },
+                    }));
+
+            })
+            .catch(error => {
+                if (error.status === 401) {
+                    dispatch(logoutAndRedirect(error));
+                }
+            });
+    };
+}

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -787,7 +787,8 @@ export class ProposalDefinition extends Component {
         let date_start = this.state.date_start;
         date_start.setHours(0, 0, 0, 0);
 
-        let date_end = this.state.date_end;
+        let date_end;
+        date_end = (this.state.date_end)?this.state.date_end:this.state.date_start;
         date_end.setHours(0, 0, 0, 0);
 
         const proposalData = {

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -55,6 +55,7 @@ export class SettingsSources extends React.Component {
                 const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
                 return (
                     [
+                        entry._id,
                         entry.name,
                         entry.alias,
                         entry.type,
@@ -72,6 +73,7 @@ export class SettingsSources extends React.Component {
                 const db_fields = entry.config[0] + ":" + entry.config[1] + "@" + entry.config[2] + "/" + entry.config[3];
                 return (
                     [
+                        entry._id,
                         entry.name,
                         entry.alias,
                         entry.type,
@@ -85,6 +87,10 @@ export class SettingsSources extends React.Component {
 
             const headers = [
                 {
+                    title: 'ID',
+                    width: null,
+                    hide: true,
+                },{
                     title: 'Name',
                     width: null,
                 },{

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -41,6 +41,11 @@ export class SettingsSources extends React.Component {
         this.props.updateSettings(token, data);
     }
 
+    toggleStatus(data) {
+        const token = this.props.token;
+        this.props.toggleSourceSettings(token, data);
+    }
+
     render() {
         if (this.props.loaded) {
 
@@ -157,14 +162,14 @@ export class SettingsSources extends React.Component {
                         header={headers}
                         data={measures_adapted}
                         appendButtons={toggle_active}
-                        onUpdate={(changed_data) => this.updateData(changed_data)}
+                        onUpdate={(changed_data) => this.toggleStatus(changed_data)}
                     />
                     <SmartTable
                         title="Static Data"
                         header={headers}
                         data={static_data_adapted}
                         appendButtons={toggle_active}
-                        onUpdate={(changed_data) => this.updateData(changed_data)}
+                        onUpdate={(changed_data) => this.toggleStatus(changed_data)}
                     />
                 </div>
             )

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -60,6 +60,7 @@ export class SettingsSources extends React.Component {
                         entry.type,
                         entry.unit,
                         db_fields,
+                        entry.priority,
                         active,
                     ]
                 )
@@ -76,6 +77,7 @@ export class SettingsSources extends React.Component {
                         entry.type,
                         entry.unit,
                         db_fields,
+                        entry.priority,
                         active,
                     ]
                 )
@@ -85,19 +87,22 @@ export class SettingsSources extends React.Component {
                 {
                     title: 'Name',
                     width: null,
-                },                {
+                },{
                     title: 'Alias',
                     width: null,
-                },                {
+                },{
                     title: 'Type',
                     width: '10%',
-                },                {
+                },{
                     title: 'Unit',
                     width: '10%',
-                },                {
+                },{
                     title: 'DB',
                     width: '30%',
-                },                {
+                },{
+                    title: 'Priority',
+                    width: '10%',
+                },{
                     title: 'Status',
                     width: null,
                 },
@@ -110,7 +115,6 @@ export class SettingsSources extends React.Component {
                     'action':
                         function(e, selectedIDs, onUpdate) {
                             e.preventDefault();
-                            console.log("toggle", selectedIDs);
 
                             const sources_parsed = (selectedIDs)?
                                 selectedIDs.map( function(entry, idx) {

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -108,9 +108,10 @@ export class SettingsSources extends React.Component {
                 {
                     'label': 'Toggle Status',
                     'action':
-                        function(e) {
+                        function(e, selectedIDs) {
                             e.preventDefault();
-                            console.log("toggle");
+                            console.log("toggle", selectedIDs);
+                            //this.updateData()
                         }
                 },
             ]

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -108,10 +108,30 @@ export class SettingsSources extends React.Component {
                 {
                     'label': 'Toggle Status',
                     'action':
-                        function(e, selectedIDs) {
+                        function(e, selectedIDs, onUpdate) {
                             e.preventDefault();
                             console.log("toggle", selectedIDs);
-                            //this.updateData()
+
+                            const sources_parsed = (selectedIDs)?
+                                selectedIDs.map( function(entry, idx) {
+                                    return {
+                                        "name": entry[0],
+                                        "alias": entry[1],
+                                        "type": entry[2],
+                                        "unit": entry[3],
+                                        "db": entry[4],
+                                        "priority": entry[5],
+                                        "active": entry[6],
+                                    }
+                                })
+                                :
+                                null;
+
+
+                            // Try to update data
+                            if (onUpdate) {
+                                onUpdate(selectedIDs);
+                            }
                         }
                 },
             ]
@@ -122,8 +142,20 @@ export class SettingsSources extends React.Component {
             (
                 <div>
                     <h2>Available sources</h2>
-                    <SmartTable title="Measures" header={headers} data={measures_adapted} appendButtons={toggle_active}/>
-                    <SmartTable title="Static Data" header={headers} data={static_data_adapted} appendButtons={toggle_active}/>
+                    <SmartTable
+                        title="Measures"
+                        header={headers}
+                        data={measures_adapted}
+                        appendButtons={toggle_active}
+                        onUpdate={(changed_data) => this.updateData(changed_data)}
+                    />
+                    <SmartTable
+                        title="Static Data"
+                        header={headers}
+                        data={static_data_adapted}
+                        appendButtons={toggle_active}
+                        onUpdate={(changed_data) => this.updateData(changed_data)}
+                    />
                 </div>
             )
             return Settings;

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -103,14 +103,26 @@ export class SettingsSources extends React.Component {
                 },
             ];
 
+            //Toggle Status BUTTON to inject in SmartTable
+            const toggle_active = [
+                {
+                    'label': 'Toggle Status',
+                    'action':
+                        function(e) {
+                            e.preventDefault();
+                            console.log("toggle");
+                        }
+                },
+            ]
+
             const Settings = (this.props.lite)?
             <SmartTable header={headers} data={measures_adapted}/>
             :
             (
                 <div>
                     <h2>Available sources</h2>
-                    <SmartTable title="Measures" header={headers} data={measures_adapted}/>
-                    <SmartTable title="Static Data" header={headers} data={static_data_adapted}/>
+                    <SmartTable title="Measures" header={headers} data={measures_adapted} appendButtons={toggle_active}/>
+                    <SmartTable title="Static Data" header={headers} data={static_data_adapted} appendButtons={toggle_active}/>
                 </div>
             )
             return Settings;

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -186,18 +186,21 @@ export class SmartTable extends Component {
 
                       { //Prepare headers with optional width
                           header_list.map(function(header, index) {
-                              if (header.hide != true)
-                                  return (
-                                      header.width?
-                                        <TableHeaderColumn
-                                            key={"data_header_" + index}
-                                            style={{width:header.width}}
-                                        >{header.title}</TableHeaderColumn>
-                                      :
-                                        <TableHeaderColumn
-                                            key={"data_header_" + index}
-                                        >{header.title}</TableHeaderColumn>
-                                  )
+                              const is_hidden = (header.hide != true)?false:true;
+
+                              return (
+                                  header.width?
+                                    <TableHeaderColumn
+                                        key={"data_header_" + index}
+                                        style={{width:header.width}}
+                                        hidden={is_hidden}
+                                    >{header.title}</TableHeaderColumn>
+                                  :
+                                    <TableHeaderColumn
+                                        key={"data_header_" + index}
+                                        hidden={is_hidden}
+                                    >{header.title}</TableHeaderColumn>
+                              )
                           })
                       }
 
@@ -221,19 +224,22 @@ export class SmartTable extends Component {
 
                                 { //For each header
                                     header_list.map(function(header, index_header) {
-                                        if (header.hide != true)
-                                            return (
-                                                header.width?
-                                                  <TableRowColumn
-                                                      key={"data_row_" + index_header}
-                                                      style={{width:header.width}}
-                                                  >{entry[index_header]}</TableRowColumn>
-                                                :
-                                                  <TableRowColumn
-                                                      key={"data_row_" + index_header}
-                                                  >{entry[index_header]}</TableRowColumn>
-                                            )
-                                        })
+                                        const is_hidden = (header.hide != true)?false:true;
+
+                                        return (
+                                            header.width?
+                                              <TableRowColumn
+                                                  key={"data_row_" + index_header}
+                                                  style={{width:header.width}}
+                                                  hidden={is_hidden}
+                                              >{entry[index_header]}</TableRowColumn>
+                                            :
+                                              <TableRowColumn
+                                                  key={"data_row_" + index_header}
+                                                  hidden={is_hidden}
+                                              >{entry[index_header]}</TableRowColumn>
+                                        )
+                                    })
                                 }
 
                                 </TableRow>

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -155,7 +155,7 @@ export class SmartTable extends Component {
                       key={button.label + "Button"}
                       label={button.label}
                       primary={true}
-                      onTouchTap={(e) => button.action(e)}
+                      onTouchTap={(e) => button.action(e, selectedEntrys)}
                       disabled={false}
                     />
                 )

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -23,7 +23,7 @@ export class SmartTable extends Component {
             disableEdit: true,
             //Flag to disable Delete action
             disableDelete: true,
-
+            disableExtended: true,
             //The list of index position of the selected elements
             selectedIDs: [],
 
@@ -50,7 +50,7 @@ export class SmartTable extends Component {
     handleSelection(selections) {
         const table = this.state.table;
 
-        let oneSelected, groupSelected, disableCreate, disableEdit, disableDelete;
+        let oneSelected, groupSelected, disableCreate, disableEdit, disableDelete, disableExtended;
         let selectedIDs = [];
         let selectedEntrys = [];
 
@@ -105,17 +105,21 @@ export class SmartTable extends Component {
         //Disable Delete if all entry are selected, or none was selected
         disableDelete = (selection_length == table.length)?true:!(oneSelected || groupSelected);
 
+        //Disable Extended if no entry is selected
+        disableExtended = (selection_length > 0)?false:true;
+
         this.setState ({
             selectedIDs,
             selectedEntrys,
             disableCreate,
             disableEdit,
             disableDelete,
+            disableExtended,
         })
     }
 
     render() {
-        const {selectedIDs, selectedEntrys, disableCreate, disableEdit, disableDelete} = this.state;
+        const {selectedIDs, selectedEntrys, disableCreate, disableEdit, disableDelete, disableExtended} = this.state;
 
         const table = this.props.data;
         const header_list = this.props.header;
@@ -155,7 +159,7 @@ export class SmartTable extends Component {
                       label={button.label}
                       primary={false}
                       onTouchTap={(e) => button.action(e, selectedEntrys, onUpdate)}
-                      disabled={false}
+                      disabled={disableExtended}
                     />
                 )
             })

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -186,17 +186,18 @@ export class SmartTable extends Component {
 
                       { //Prepare headers with optional width
                           header_list.map(function(header, index) {
-                              return (
-                                  header.width?
-                                    <TableHeaderColumn
-                                        key={"data_header_" + index}
-                                        style={{width:header.width}}
-                                    >{header.title}</TableHeaderColumn>
-                                  :
-                                    <TableHeaderColumn
-                                        key={"data_header_" + index}
-                                    >{header.title}</TableHeaderColumn>
-                              )
+                              if (header.hide != true)
+                                  return (
+                                      header.width?
+                                        <TableHeaderColumn
+                                            key={"data_header_" + index}
+                                            style={{width:header.width}}
+                                        >{header.title}</TableHeaderColumn>
+                                      :
+                                        <TableHeaderColumn
+                                            key={"data_header_" + index}
+                                        >{header.title}</TableHeaderColumn>
+                                  )
                           })
                       }
 
@@ -220,18 +221,19 @@ export class SmartTable extends Component {
 
                                 { //For each header
                                     header_list.map(function(header, index_header) {
-                                        return (
-                                            header.width?
-                                              <TableRowColumn
-                                                  key={"data_row_" + index_header}
-                                                  style={{width:header.width}}
-                                              >{entry[index_header]}</TableRowColumn>
-                                            :
-                                              <TableRowColumn
-                                                  key={"data_row_" + index_header}
-                                              >{entry[index_header]}</TableRowColumn>
-                                        )
-                                    })
+                                        if (header.hide != true)
+                                            return (
+                                                header.width?
+                                                  <TableRowColumn
+                                                      key={"data_row_" + index_header}
+                                                      style={{width:header.width}}
+                                                  >{entry[index_header]}</TableRowColumn>
+                                                :
+                                                  <TableRowColumn
+                                                      key={"data_row_" + index_header}
+                                                  >{entry[index_header]}</TableRowColumn>
+                                            )
+                                        })
                                 }
 
                                 </TableRow>

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -153,7 +153,7 @@ export class SmartTable extends Component {
                     <RaisedButton
                       key={button.label + "Button"}
                       label={button.label}
-                      primary={true}
+                      primary={false}
                       onTouchTap={(e) => button.action(e, selectedEntrys, onUpdate)}
                       disabled={false}
                     />

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -119,7 +119,7 @@ export class SmartTable extends Component {
 
         const table = this.props.data;
         const header_list = this.props.header;
-        const appendButtons = this.props.appendButtons;
+        const {appendButtons, onUpdate} = this.props;
 
         const defaultActions = [
             <RaisedButton
@@ -147,7 +147,6 @@ export class SmartTable extends Component {
             />
         ]
 
-        console.log(appendButtons);
         const extendedActions = (appendButtons != null)?
             appendButtons.map(function(button, id) {
                 return (
@@ -155,7 +154,7 @@ export class SmartTable extends Component {
                       key={button.label + "Button"}
                       label={button.label}
                       primary={true}
-                      onTouchTap={(e) => button.action(e, selectedEntrys)}
+                      onTouchTap={(e) => button.action(e, selectedEntrys, onUpdate)}
                       disabled={false}
                     />
                 )

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -118,10 +118,10 @@ export class SmartTable extends Component {
         const {selectedIDs, selectedEntrys, disableCreate, disableEdit, disableDelete} = this.state;
 
         const table = this.props.data;
-
         const header_list = this.props.header;
+        const appendButtons = this.props.appendButtons;
 
-        const actions = [
+        const defaultActions = [
             <RaisedButton
               key="createButton"
               label='New'
@@ -146,6 +146,24 @@ export class SmartTable extends Component {
               disabled={disableDelete}
             />
         ]
+
+        console.log(appendButtons);
+        const extendedActions = (appendButtons != null)?
+            appendButtons.map(function(button, id) {
+                return (
+                    <RaisedButton
+                      key={button.label + "Button"}
+                      label={button.label}
+                      primary={true}
+                      onTouchTap={(e) => button.action(e)}
+                      disabled={false}
+                    />
+                )
+            })
+            :
+            null;
+
+        const actions = defaultActions.concat(extendedActions)
 
         return  (
             <Paper>
@@ -250,4 +268,5 @@ SmartTable.propTypes = {
     header: React.PropTypes.array.isRequired,
     data: React.PropTypes.array.isRequired,
     title: React.PropTypes.string,
+    appendButtons: React.PropTypes.array,
 };


### PR DESCRIPTION
Provide all needed changes to ensure that a source status can be toggled.

The sources list can be selected, and if at least one element is selected, the toggle button is activated.

When the toggle is asked, it request to the API about to refresh the selected IDs.

Fix #184 :: Toggle Source Status