### PR TITLE
Proptypes standardization

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,8 @@
       "file-saver": "latest",
       "raven-js": "latest",
       "raven-for-redux": "latest",
-      
-      "prop-types": "latest"
+
+      "prop-types": "^15.5.10"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,9 @@
       "blueimp-md5": "latest",
       "file-saver": "latest",
       "raven-js": "latest",
-      "raven-for-redux": "latest"
+      "raven-for-redux": "latest",
+      
+      "prop-types": "latest"
   },
   "dependencies": {}
 }

--- a/src/components/AboutView.js
+++ b/src/components/AboutView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/about';
@@ -103,8 +104,8 @@ export default class ProfileView extends React.Component {
 }
 
 ProfileView.propTypes = {
-    fetchVersion: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchVersion: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/AggregationsView.js
+++ b/src/components/AggregationsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/aggregations';
@@ -81,7 +82,7 @@ export default class AggregationsView extends React.Component {
             <div>
                 {
                     (!this.props.loaded) ?
-                        <LoadingAnimation /> || 
+                        <LoadingAnimation /> ||
                         this.props.error &&
                             <div>
                                 <h1>There was an error</h1>
@@ -100,9 +101,9 @@ export default class AggregationsView extends React.Component {
 }
 
 AggregationsView.propTypes = {
-    aggregations: React.PropTypes.object,
-    fetchAggregations: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    aggregations: PropTypes.object,
+    fetchAggregations: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/AuthenticatedComponent.js
+++ b/src/components/AuthenticatedComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';
@@ -76,8 +77,8 @@ export function requireAuthentication(Component) {
     }
 
     AuthenticatedComponent.propTypes = {
-        loginUserSuccess: React.PropTypes.func,
-        isAuthenticated: React.PropTypes.bool,
+        loginUserSuccess: PropTypes.func,
+        isAuthenticated: PropTypes.bool,
     };
 
     return connect(mapStateToProps, mapDispatchToProps)(AuthenticatedComponent);

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { dispatchNewRoute} from '../../utils/http_functions';
@@ -62,5 +63,5 @@ export default class Breadcrumb extends React.Component {
 }
 
 Breadcrumb.propTypes = {
-    path: React.PropTypes.string,
+    path: PropTypes.string,
 };

--- a/src/components/ContentHeader/index.js
+++ b/src/components/ContentHeader/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-
+import PropTypes from 'prop-types';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
 import ContentAdd from 'material-ui/svg-icons/content/add';
 import Refresh from 'material-ui/svg-icons/navigation/refresh';
@@ -67,9 +67,9 @@ export class ContentHeader extends Component {
 }
 
 ContentHeader.propTypes = {
-    title: React.PropTypes.string.isRequired,
-    addButton: React.PropTypes.bool,
-    refreshButton: React.PropTypes.bool,
-    addClickMethod: React.PropTypes.func,
-    refreshClickMethod: React.PropTypes.func,
+    title: PropTypes.string.isRequired,
+    addButton: PropTypes.bool,
+    refreshButton: PropTypes.bool,
+    addClickMethod: PropTypes.func,
+    refreshClickMethod: PropTypes.func,
 };

--- a/src/components/DetermineAuth.js
+++ b/src/components/DetermineAuth.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/auth';
@@ -68,7 +69,7 @@ export function DetermineAuth(Component) {
     }
 
     AuthenticatedComponent.propTypes = {
-        loginUserSuccess: React.PropTypes.func,
+        loginUserSuccess: PropTypes.func,
     };
 
     return connect(mapStateToProps, mapDispatchToProps)(AuthenticatedComponent);

--- a/src/components/ElementsDashboard/index.js
+++ b/src/components/ElementsDashboard/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -265,6 +266,6 @@ export class ElementsDashboard extends Component {
 }
 
 ElementsDashboard.propTypes = {
-    elements: React.PropTypes.array.isRequired,
-    aggregations: React.PropTypes.object.isRequired,
+    elements: PropTypes.array.isRequired,
+    aggregations: PropTypes.object.isRequired,
 };

--- a/src/components/ElementsView.js
+++ b/src/components/ElementsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -53,7 +54,7 @@ export default class ElementsView extends React.Component {
             message_text: null,
         };
     }
-    
+
     componentDidMount() {
         this.fetchData();
     }
@@ -119,8 +120,8 @@ export default class ElementsView extends React.Component {
 }
 
 ElementsView.propTypes = {
-    fetchProposals: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchProposals: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import AppBar from 'material-ui/AppBar';
@@ -214,6 +215,6 @@ export class Header extends Component {
 }
 
 Header.propTypes = {
-    logoutAndRedirect: React.PropTypes.func,
-    isAuthenticated: React.PropTypes.bool,
+    logoutAndRedirect: PropTypes.func,
+    isAuthenticated: PropTypes.bool,
 };

--- a/src/components/Historical/index.js
+++ b/src/components/Historical/index.js
@@ -11,6 +11,7 @@ toDo: create a dummy component to render data from Proposal and Historical and k
 
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -693,7 +694,7 @@ export class Historical extends Component {
 }
 
 Historical.propTypes = {
-    readOnly: React.PropTypes.bool,
-    proposalOld: React.PropTypes.bool,
-    comparation: React.PropTypes.bool,
+    readOnly: PropTypes.bool,
+    proposalOld: PropTypes.bool,
+    comparation: PropTypes.bool,
 };

--- a/src/components/HistoricalView.js
+++ b/src/components/HistoricalView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -70,7 +71,7 @@ export default class HistoricalView extends React.Component {
 }
 
 HistoricalView.propTypes = {
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/HistoricalsView.js
+++ b/src/components/HistoricalsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/historicals';
@@ -105,9 +106,9 @@ export default class HistoricalsView extends React.Component {
 }
 
 HistoricalsView.propTypes = {
-    fetchProtectedDataHistoricals: React.PropTypes.func,
-    fetchProtectedData: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchProtectedDataHistoricals: PropTypes.func,
+    fetchProtectedData: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/HistoryNewView.js
+++ b/src/components/HistoryNewView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { debug } from '../utils/debug';
@@ -57,6 +58,6 @@ export default class HistoryNewView extends React.Component {
 }
 
 HistoryNewView.propTypes = {
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/Indicator/index.js
+++ b/src/components/Indicator/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Paper from 'material-ui/Paper';
@@ -135,18 +136,18 @@ export class Indicator extends Component {
                     <h3 style={styles.header}>{title}</h3>
 
                     {separator}
-                    <span title={valueInfo} style={styles.value}>{value_list[0]}</span> 
+                    <span title={valueInfo} style={styles.value}>{value_list[0]}</span>
                     {
                         (has_unit) &&
-                        <span 
+                        <span
                             style={styles.valueUnit}
                         >{value_list[1]}
                         </span>
                     }
 
-                    { 
+                    {
                         (hasSubvalue) &&
-                    <span 
+                    <span
                         title={subvalueInfo}
                         style={styles.subvalue}
                     >
@@ -164,19 +165,19 @@ export class Indicator extends Component {
 }
 
 Indicator.propTypes = {
-    title: React.PropTypes.string.isRequired,
-    value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
+    title: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
     ]).isRequired,
-    subvalue: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number,
+    subvalue: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
     ]),
-    valueInfo: React.PropTypes.string,
-    subvalueInfo: React.PropTypes.string,
-    percentage: React.PropTypes.bool,
-    total: React.PropTypes.number,
-    small: React.PropTypes.bool,
-    color: React.PropTypes.string,
+    valueInfo: PropTypes.string,
+    subvalueInfo: PropTypes.string,
+    percentage: PropTypes.bool,
+    total: PropTypes.number,
+    small: PropTypes.bool,
+    color: PropTypes.string,
 };

--- a/src/components/LoginView.js
+++ b/src/components/LoginView.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0, no-underscore-dangle: 0 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import TextField from 'material-ui/TextField';
@@ -183,7 +184,7 @@ export default class LoginView extends React.Component {
 }
 
 LoginView.propTypes = {
-    loginUser: React.PropTypes.func,
-    statusText: React.PropTypes.string,
-    statusType: React.PropTypes.string,
+    loginUser: PropTypes.func,
+    statusText: PropTypes.string,
+    statusType: PropTypes.string,
 };

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import Snackbar from 'material-ui/Snackbar';
 
@@ -69,7 +70,7 @@ export class Notification extends Component {
 }
 
 Notification.propTypes = {
-    open: React.PropTypes.bool,
-    message: React.PropTypes.string,
-    width: React.PropTypes.number,
+    open: PropTypes.bool,
+    message: PropTypes.string,
+    width: PropTypes.number,
 };

--- a/src/components/PRDetail/index.js
+++ b/src/components/PRDetail/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+import PropTypes from 'prop-types';
 import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
 import FlatButton from 'material-ui/FlatButton';
 
@@ -87,6 +88,6 @@ export class PRDetail extends Component {
 }
 
 PRDetail.propTypes = {
-    PR: React.PropTypes.object.isRequired,
-    open: React.PropTypes.bool,
+    PR: PropTypes.object.isRequired,
+    open: PropTypes.bool,
 };

--- a/src/components/PasswordChanger/index.js
+++ b/src/components/PasswordChanger/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 
+import PropTypes from 'prop-types';
 import TextField from 'material-ui/TextField';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
@@ -60,5 +61,5 @@ export class PasswordChanger extends Component {
 }
 
 PasswordChanger.propTypes = {
-    open: React.PropTypes.bool,
+    open: PropTypes.bool,
 };

--- a/src/components/PasswordStepper/index.js
+++ b/src/components/PasswordStepper/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../../actions/password';
@@ -426,5 +427,5 @@ export class PasswordStepper extends Component {
 }
 
 PasswordStepper.propTypes = {
-    closeMe: React.PropTypes.func,
+    closeMe: PropTypes.func,
 };

--- a/src/components/ProfileView.js
+++ b/src/components/ProfileView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/profile';
@@ -46,7 +47,7 @@ export default class ProfileView extends React.Component {
             <div>
                 {
                     (!this.props.loaded) ?
-                        <LoadingAnimation /> || 
+                        <LoadingAnimation /> ||
                         this.props.error &&
                             <div>
                                 <h1>There was an error</h1>
@@ -66,9 +67,9 @@ export default class ProfileView extends React.Component {
 }
 
 ProfileView.propTypes = {
-    fetchProfile: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    userName: React.PropTypes.string,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchProfile: PropTypes.func,
+    loaded: PropTypes.bool,
+    userName: PropTypes.string,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -704,7 +705,7 @@ export class Proposal extends Component {
 }
 
 Proposal.propTypes = {
-    readOnly: React.PropTypes.bool,
-    proposalOld: React.PropTypes.bool,
-    comparation: React.PropTypes.bool,
+    readOnly: PropTypes.bool,
+    proposalOld: PropTypes.bool,
+    comparation: PropTypes.bool,
 };

--- a/src/components/ProposalComparator/index.js
+++ b/src/components/ProposalComparator/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 
 import { Proposal } from '../Proposal'
 import { Historical } from '../Historical'
@@ -166,9 +167,9 @@ export class ProposalComparator extends Component {
 }
 
 ProposalComparator.propTypes = {
-    elementA: React.PropTypes.object.isRequired,
-    elementB: React.PropTypes.object.isRequired,
-    comparison: React.PropTypes.object.isRequired,
-    title: React.PropTypes.string,
-    mode: React.PropTypes.string.isRequired,
+    elementA: PropTypes.object.isRequired,
+    elementB: PropTypes.object.isRequired,
+    comparison: PropTypes.object.isRequired,
+    title: PropTypes.string,
+    mode: PropTypes.string.isRequired,
 };

--- a/src/components/ProposalComparatorView.js
+++ b/src/components/ProposalComparatorView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -112,7 +113,7 @@ export default class ProposalComparatorView extends React.Component {
 }
 
 ProposalComparatorView.propTypes = {
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/ProposalDefinition/index.js
+++ b/src/components/ProposalDefinition/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -833,5 +834,5 @@ export class ProposalDefinition extends Component {
 }
 
 ProposalDefinition.propTypes = {
-    open: React.PropTypes.bool,
+    open: PropTypes.bool,
 };

--- a/src/components/ProposalDetail/index.js
+++ b/src/components/ProposalDetail/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 
@@ -191,8 +192,8 @@ export class ProposalDetail extends Component {
 }
 
 ProposalDetail.propTypes = {
-    data: React.PropTypes.object.isRequired,
-    open: React.PropTypes.bool,
-    colors: React.PropTypes.object,
-    avg_info: React.PropTypes.object,
+    data: PropTypes.object.isRequired,
+    open: PropTypes.bool,
+    colors: PropTypes.object,
+    avg_info: PropTypes.object,
 };

--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {ComposedChart, AreaChart, Area, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend} from 'recharts';
@@ -233,13 +234,13 @@ export class ProposalGraph extends Component {
 }
 
 ProposalGraph.propTypes = {
-    data: React.PropTypes.array,
-    components: React.PropTypes.object,
-    stacked: React.PropTypes.bool,
-    isLite: React.PropTypes.bool,
-    areaChart: React.PropTypes.bool,
-    animated: React.PropTypes.bool,
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
-    unit: React.PropTypes.string,
+    data: PropTypes.array,
+    components: PropTypes.object,
+    stacked: PropTypes.bool,
+    isLite: PropTypes.bool,
+    areaChart: PropTypes.bool,
+    animated: PropTypes.bool,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    unit: PropTypes.string,
 };

--- a/src/components/ProposalGraphOld/index.js
+++ b/src/components/ProposalGraphOld/index.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import {AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer} from 'recharts';
 
@@ -83,9 +84,9 @@ export class ProposalGraphOld extends Component {
 }
 
 ProposalGraphOld.propTypes = {
-    proposal: React.PropTypes.object,
-    stacked: React.PropTypes.bool,
-    isLite: React.PropTypes.bool,
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
+    proposal: PropTypes.object,
+    stacked: PropTypes.bool,
+    isLite: PropTypes.bool,
+    width: PropTypes.number,
+    height: PropTypes.number,
 };

--- a/src/components/ProposalList/index.js
+++ b/src/components/ProposalList/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -223,6 +224,6 @@ export class ProposalList extends Component {
 }
 
 ProposalList.propTypes = {
-    sameWidth: React.PropTypes.bool,
-    width: React.PropTypes.string,
+    sameWidth: PropTypes.bool,
+    width: PropTypes.string,
 };

--- a/src/components/ProposalNewView.js
+++ b/src/components/ProposalNewView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { debug } from '../utils/debug';
@@ -56,6 +57,6 @@ export default class ProfileView extends React.Component {
 }
 
 ProfileView.propTypes = {
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/ProposalTableMaterial/index.js
+++ b/src/components/ProposalTableMaterial/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
@@ -234,10 +235,10 @@ export class ProposalTableMaterial extends Component {
 }
 
 ProposalTableMaterial.propTypes = {
-    data: React.PropTypes.array.isRequired,
-    components: React.PropTypes.object.isRequired,
-    colors: React.PropTypes.object,
-    type: React.PropTypes.bool,
-    totals: React.PropTypes.bool,
-    unit: React.PropTypes.string,
+    data: PropTypes.array.isRequired,
+    components: PropTypes.object.isRequired,
+    colors: PropTypes.object,
+    type: PropTypes.bool,
+    totals: PropTypes.bool,
+    unit: PropTypes.string,
 };

--- a/src/components/ProposalView.js
+++ b/src/components/ProposalView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -70,7 +71,7 @@ export default class ProposalView extends React.Component {
 }
 
 ProposalView.propTypes = {
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/ProposalsView.js
+++ b/src/components/ProposalsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/proposals';
@@ -105,9 +106,9 @@ export default class ProposalsView extends React.Component {
 }
 
 ProposalsView.propTypes = {
-    fetchProtectedDataProposals: React.PropTypes.func,
-    fetchProtectedData: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchProtectedDataProposals: PropTypes.func,
+    fetchProtectedData: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/ProtectedView.js
+++ b/src/components/ProtectedView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/data';
@@ -47,9 +48,9 @@ export default class ProtectedView extends React.Component {
 }
 
 ProtectedView.propTypes = {
-    fetchProtectedData: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    userName: React.PropTypes.string,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchProtectedData: PropTypes.func,
+    loaded: PropTypes.bool,
+    userName: PropTypes.string,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/RegisterView.js
+++ b/src/components/RegisterView.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0, no-underscore-dangle: 0 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import TextField from 'material-ui/TextField';
@@ -163,6 +164,6 @@ export default class RegisterView extends React.Component {
 }
 
 RegisterView.propTypes = {
-    registerUser: React.PropTypes.func,
-    registerStatusText: React.PropTypes.string,
+    registerUser: PropTypes.func,
+    registerStatusText: PropTypes.string,
 };

--- a/src/components/SettingsSources/index.js
+++ b/src/components/SettingsSources/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -180,8 +181,8 @@ export class SettingsSources extends React.Component {
 }
 
 SettingsSources.propTypes = {
-    measures: React.PropTypes.array,
-    static_data: React.PropTypes.array,
-    reload: React.PropTypes.bool,
-    lite: React.PropTypes.bool,
+    measures: PropTypes.array,
+    static_data: PropTypes.array,
+    reload: PropTypes.bool,
+    lite: PropTypes.bool,
 };

--- a/src/components/SettingsView.js
+++ b/src/components/SettingsView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actionCreators from '../actions/settings';
@@ -56,7 +57,7 @@ export default class SettingsView extends React.Component {
             <div>
                 {
                     (!this.props.loaded) ?
-                        <LoadingAnimation /> || 
+                        <LoadingAnimation /> ||
                         this.props.error &&
                             <div>
                                 <h1>There was an error fetching data</h1>
@@ -77,8 +78,8 @@ export default class SettingsView extends React.Component {
 }
 
 SettingsView.propTypes = {
-    fetchSettings: React.PropTypes.func,
-    loaded: React.PropTypes.bool,
-    data: React.PropTypes.any,
-    token: React.PropTypes.string,
+    fetchSettings: PropTypes.func,
+    loaded: PropTypes.bool,
+    data: PropTypes.any,
+    token: PropTypes.string,
 };

--- a/src/components/SmartTable/index.js
+++ b/src/components/SmartTable/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -276,8 +277,8 @@ export class SmartTable extends Component {
 }
 
 SmartTable.propTypes = {
-    header: React.PropTypes.array.isRequired,
-    data: React.PropTypes.array.isRequired,
-    title: React.PropTypes.string,
-    appendButtons: React.PropTypes.array,
+    header: PropTypes.array.isRequired,
+    data: PropTypes.array.isRequired,
+    title: PropTypes.string,
+    appendButtons: PropTypes.array,
 };

--- a/src/components/notAuthenticatedComponent.js
+++ b/src/components/notAuthenticatedComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';
@@ -76,8 +77,8 @@ export function requireNoAuthentication(Component) {
     }
 
     notAuthenticatedComponent.propTypes = {
-        loginUserSuccess: React.PropTypes.func,
-        isAuthenticated: React.PropTypes.bool,
+        loginUserSuccess: PropTypes.func,
+        isAuthenticated: PropTypes.bool,
     };
 
     return connect(mapStateToProps, mapDispatchToProps)(notAuthenticatedComponent);

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /* theme creation */
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -35,7 +36,7 @@ import './styles/app.scss';
 
 class App extends React.Component { // eslint-disable-line react/prefer-stateless-function
     static propTypes = {
-        children: React.PropTypes.node,
+        children: PropTypes.node,
     };
 
     render() {


### PR DESCRIPTION
It solves React Proptypes deprecation integrating the prop-types package.

It fixes all the usage of Proptypes to integrate with this, instead of the React one (that will be deprecated on v16).

Fix #202 React.PropTypes deprecation