### PR TITLE
Avoid to use React classes

### DIFF
--- a/src/components/ProposalGraph/index.js
+++ b/src/components/ProposalGraph/index.js
@@ -32,13 +32,7 @@ const styles = {
     },
 };
 
-const CustomTooltip  = React.createClass({
-  propTypes: {
-    type: PropTypes.string,
-    payload: PropTypes.array,
-    label: PropTypes.any,
-  },
-
+export class CustomTooltip extends Component {
   render() {
     const { active } = this.props;
 
@@ -78,7 +72,14 @@ const CustomTooltip  = React.createClass({
 
     return null;
   }
-});
+};
+
+CustomTooltip.propTypes = {
+  type: PropTypes.string,
+  payload: PropTypes.array,
+  label: PropTypes.any,
+};
+
 
 export class ProposalGraph extends Component {
     constructor(props) {


### PR DESCRIPTION
It create plain JS classes instead of using React ones, due to the deprecation of this.

It Fix #204