### PR TITLE
Service workers integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,10 @@
       "raven-for-redux": "latest",
 
       "prop-types": "^15.5.10",
-      "materialized-reactions": "latest"
+      "materialized-reactions": "latest",
+      
+      "offline-plugin"
+      
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -118,8 +118,7 @@
       "prop-types": "^15.5.10",
       "materialized-reactions": "latest",
       
-      "offline-plugin"
-      
+      "offline-plugin": "latest"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,9 @@
     "react",
     "reactjs",
     "redux",
-    "hot",
-    "reload",
-    "hmr",
-    "live",
-    "edit",
-    "webpack"
+    "orakwlum",
+    "okW",
+    "prediction"
   ],
   "author": "https://github.com/xavitorello, https://github.com/gisce",
   "license": "MIT",

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -10,8 +10,8 @@ function mapStateToProps(state) {
 }
 
 export default class Breadcrumb extends React.Component {
-    dispatchRoute(route) {
-        dispatchNewRoute(route);
+    dispatchRoute(event, route) {
+        dispatchNewRoute(route, event);
         this.setState({
             open: false,
         });
@@ -47,7 +47,7 @@ export default class Breadcrumb extends React.Component {
 
                                 section = section[0].toUpperCase() + section.slice(1);
                                 return <li
-                                            onClick={() => this.dispatchRoute(sectionUrl[index])}
+                                            onClick={(event) => this.dispatchRoute(event, sectionUrl[index])}
                                             key={index}
                                             className={classActive}
                                         >

--- a/src/components/ElementsDashboard/index.js
+++ b/src/components/ElementsDashboard/index.js
@@ -11,7 +11,6 @@ import TextField from 'material-ui/TextField';
 
 import { ProposalList } from '../ProposalList';
 
-import { dispatchNewRoute} from '../../utils/http_functions';
 import { date_to_string} from '../../utils/misc';
 
 import * as actionCreators from '../../actions/elements';

--- a/src/components/ElementsView.js
+++ b/src/components/ElementsView.js
@@ -72,8 +72,8 @@ export default class ElementsView extends React.Component {
         });
     }
 
-    addElement() {
-        dispatchNewRoute("/proposals/new");
+    addElement(event) {
+        dispatchNewRoute("/proposals/new", event);
     }
 
     render() {
@@ -91,7 +91,7 @@ export default class ElementsView extends React.Component {
                 <ContentHeader
         		    title="Dashboard"
         		    addButton={true}
-        		    addClickMethod={() => this.addElement()}
+        		    addClickMethod={(event) => this.addElement(event)}
 
         		    refreshButton={true}
         		    refreshClickMethod={() => this.refreshData()}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -66,8 +66,18 @@ export class Header extends Component {
 
     }
 
-    dispatchRoute(route) {
+    dispatchRoute(e, route) {
+        if (e.metaKey || e.ctrlKey) {
+            const new_window = window.open(route, '_blank');
+            new_window.focus();
+
+            return;
+        }
+
+        e.preventDefault();
+
         dispatchNewRoute(route);
+
         this.setState({
             open: false,
         });
@@ -115,12 +125,12 @@ export class Header extends Component {
                         !this.props.isAuthenticated ?
                             <div>
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/login')}
+                                    onClick={(event) => this.dispatchRoute(event,'/login')}
                                     leftIcon={<LoginIcon/>}
                                     primaryText="Login"
                                 />
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/register')}
+                                    onClick={(event) => this.dispatchRoute(event,'/register')}
                                     leftIcon={<RegisterIcon/>}
                                     primaryText="Register"
                                 />
@@ -129,7 +139,7 @@ export class Header extends Component {
                             <div>
                                 <Card
                                     style={styles.userPanel}
-                                    onClick={() => this.dispatchRoute('/profile')}
+                                    onClick={(event) => this.dispatchRoute(event,'/profile')}
                                 >
                                     <CardHeader
                                       title={this.props.userName}
@@ -141,23 +151,23 @@ export class Header extends Component {
                                 <MenuItem
                                     leftIcon={<DashboardIcon/>}
                                     primaryText={"Elements"}
-                                    onClick={() => this.dispatchRoute('/elements')}
+                                    onClick={(event) => this.dispatchRoute(event, '/elements')}
                                 />
 
                                 <Divider />
 
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/proposals')}
+                                    onClick={(event) => this.dispatchRoute(event,'/proposals')}
                                     leftIcon={<ProposalIcon/>}
                                     primaryText="Proposals"
                                 />
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/historicals')}
+                                    onClick={(event) => this.dispatchRoute(event,'/historicals')}
                                     leftIcon={<HistoryIcon/>}
                                     primaryText="Historicals"
                                 />
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/buys')}
+                                    onClick={(event) => this.dispatchRoute(event,'/buys')}
                                     leftIcon={<EuroIcon/>}
                                     primaryText="Buys"
                                     disabled
@@ -166,7 +176,7 @@ export class Header extends Component {
                                 <Divider />
 
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/aggregations')}
+                                    onClick={(event) => this.dispatchRoute(event,'/aggregations')}
                                     leftIcon={<AggregationsIcon/>}
                                     primaryText="Aggregations"
                                 />
@@ -174,17 +184,17 @@ export class Header extends Component {
                                 <Divider />
 
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/profile')}
+                                    onClick={(event) => this.dispatchRoute(event,'/profile')}
                                     leftIcon={<ProfileIcon/>}
                                     primaryText="Profile"
                                 />
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/settings')}
+                                    onClick={(event) => this.dispatchRoute(event,'/settings')}
                                     leftIcon={<SettingsIcon/>}
                                     primaryText="Settings"
                                 />
                                 <MenuItem
-                                    onClick={() => this.dispatchRoute('/about')}
+                                    onClick={(event) => this.dispatchRoute(event,'/about')}
                                     leftIcon={<AboutIcon/>}
                                     primaryText="About"
                                 />
@@ -203,7 +213,7 @@ export class Header extends Component {
                 <AppBar
                   title="orakWlum"
                   onLeftIconButtonTouchTap={() => this.openNav()}
-                  iconElementRight={<FlatButton label="Proposals" onClick={() => this.dispatchRoute('/proposals')}/>}
+                  iconElementRight={<FlatButton label="Proposals" onClick={(event) => this.dispatchRoute(event,'/proposals')}/>}
                 />
 
             <Breadcrumb path={this.props.path}/>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -66,22 +66,12 @@ export class Header extends Component {
 
     }
 
-    dispatchRoute(e, route) {
-        if (e.metaKey || e.ctrlKey) {
-            const new_window = window.open(route, '_blank');
-            new_window.focus();
-
-            return;
-        }
-
-        e.preventDefault();
-
-        dispatchNewRoute(route);
+    dispatchRoute(event, route) {
+        dispatchNewRoute(route, event);
 
         this.setState({
             open: false,
         });
-
     }
 
     handleClickOutside() {

--- a/src/components/Historical/index.js
+++ b/src/components/Historical/index.js
@@ -155,10 +155,6 @@ export class Historical extends Component {
         }
     }
 
-    dispatchNewRoute(route) {
-        browserHistory.push(route);
-    }
-
     dummyAsync = (cb) => {
         this.setState({loading: true}, () => {
             this.asyncTimer = setTimeout(cb, 2000);

--- a/src/components/HistoricalsView.js
+++ b/src/components/HistoricalsView.js
@@ -63,8 +63,8 @@ export default class HistoricalsView extends React.Component {
         });
     }
 
-    addHistorical() {
-        dispatchNewRoute("/historicals/new");
+    addHistorical(event) {
+        dispatchNewRoute("/historicals/new", event);
     }
 
     render() {
@@ -78,7 +78,7 @@ export default class HistoricalsView extends React.Component {
         		<ContentHeader
         		    title="Historicals List"
         		    addButton={true}
-        		    addClickMethod={() => this.addHistorical()}
+        		    addClickMethod={(event) => this.addHistorical(event)}
 
         		    refreshButton={true}
         		    refreshClickMethod={() => this.refreshData()}

--- a/src/components/Proposal/index.js
+++ b/src/components/Proposal/index.js
@@ -144,10 +144,6 @@ export class Proposal extends Component {
         }
     }
 
-    dispatchNewRoute(route) {
-        browserHistory.push(route);
-    }
-
     dummyAsync = (cb) => {
         this.setState({loading: true}, () => {
             this.asyncTimer = setTimeout(cb, 2000);

--- a/src/components/ProposalList/index.js
+++ b/src/components/ProposalList/index.js
@@ -148,7 +148,7 @@ export class ProposalList extends Component {
                         titleBackground="linear-gradient(to bottom, rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.3) 70%,rgba(0,0,0,0) 100%)"
                         cols={index < howManyBig ? 2 : 1}
                         rows={index < howManyBig ? 2 : 1}
-                        onClick={() => dispatchNewRoute(this.state.path + (tile.id))}
+                        onClick={(event) => dispatchNewRoute(this.state.path + (tile.id), event)}
                         style={styles.gridTile}
                     >
                     <div><br/><br/><br/><br/></div>
@@ -176,7 +176,7 @@ export class ProposalList extends Component {
                         titleBackground="linear-gradient(to bottom, rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.3) 70%,rgba(0,0,0,0) 100%)"
                         cols={index < howManyBig ? 2 : 1}
                         rows={index < howManyBig ? 2 : 1}
-                        onClick={() => dispatchNewRoute(this.state.path + (tile.id))}
+                        onClick={(event) => dispatchNewRoute(this.state.path + (tile.id), event)}
                         style={styles.gridTile}
                     >
                         <div><br/><br/><br/><br/>

--- a/src/components/ProposalsView.js
+++ b/src/components/ProposalsView.js
@@ -63,8 +63,8 @@ export default class ProposalsView extends React.Component {
         });
     }
 
-    addProposal() {
-        dispatchNewRoute("/proposals/new");
+    addProposal(event) {
+        dispatchNewRoute("/proposals/new", event);
     }
 
     render() {
@@ -78,7 +78,7 @@ export default class ProposalsView extends React.Component {
         		<ContentHeader
         		    title="Proposals List"
         		    addButton={true}
-        		    addClickMethod={() => this.addProposal()}
+        		    addClickMethod={(event) => this.addProposal(event)}
 
         		    refreshButton={true}
         		    refreshClickMethod={() => this.refreshData()}

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,18 @@ import { Router, Redirect, browserHistory } from 'react-router';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import { syncHistoryWithStore } from 'react-router-redux';
 
+//SW
+import * as OfflinePluginRuntime from 'offline-plugin/runtime';
+
 import configureStore from './store/configureStore';
 import routes from './routes';
 import './style.scss';
 
 require('expose?$!expose?jQuery!jquery');
 require('bootstrap-webpack');
+
+//SW installation
+OfflinePluginRuntime.install();
 
 injectTapEventPlugin();
 const store = configureStore();

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,11 @@ import './style.scss';
 require('expose?$!expose?jQuery!jquery');
 require('bootstrap-webpack');
 
-//SW installation
-OfflinePluginRuntime.install();
+//SW installation handling version updates!
+OfflinePluginRuntime.install({
+    onUpdateReady: () => OfflinePluginRuntime.applyUpdate(),
+    onUpdated: () => window.softwareUpdate = true,
+});
 
 injectTapEventPlugin();
 const store = configureStore();

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,5 @@
+
+// Register a listener for push events!
+self.addEventListener('push', () => {
+    console.log("new push!");
+});

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,5 +1,6 @@
+'use strict';
 
 // Register a listener for push events!
-self.addEventListener('push', () => {
-    console.log("new push!");
+self.addEventListener('push', (event) => {
+    console.log("new pushh!", event);
 });

--- a/src/utils/http_functions.js
+++ b/src/utils/http_functions.js
@@ -13,6 +13,10 @@ const tokenConfig = (token) => ({
 });
 
 export function dispatchNewRoute(route) {
+    //software update detection -> enforce a full refresh of the window to reach the updated version!
+    if (window.softwareUpdate)
+        return (window.location = route);
+
     browserHistory.push(route);
 }
 

--- a/src/utils/http_functions.js
+++ b/src/utils/http_functions.js
@@ -12,7 +12,17 @@ const tokenConfig = (token) => ({
     },
 });
 
-export function dispatchNewRoute(route) {
+export function dispatchNewRoute(route, event=false) {
+
+    //if event is provided handle opening in a new tab/window
+    if (event) {
+        if (event.metaKey || event.ctrlKey) {
+            const new_window = window.open(route, '_blank');
+            return;
+        }
+        event.preventDefault();
+    }
+
     //software update detection -> enforce a full refresh of the window to reach the updated version!
     if (window.softwareUpdate)
         return (window.location = route);

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -33,5 +33,6 @@ module.exports = {
         new webpack.ProvidePlugin({
             jQuery: 'jquery',
         }),
+        new OfflinePlugin(),
     ],
 };

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -35,6 +35,11 @@ module.exports = {
         new webpack.ProvidePlugin({
             jQuery: 'jquery',
         }),
-        new OfflinePlugin(),
+        new OfflinePlugin({
+            ServiceWorker:{
+                entry: 'sw.js',
+                events: true,
+            }
+        }),
     ],
 };

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -36,9 +36,12 @@ module.exports = {
             jQuery: 'jquery',
         }),
         new OfflinePlugin({
+            updateStrategy: 'changed',
+            autoUpdate: 1000 * 60 * 60 * 1, //1h
             ServiceWorker:{
                 entry: 'sw.js',
                 events: true,
+                navigateFallbackURL: '/',
             }
         }),
     ],

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -1,6 +1,8 @@
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+var OfflinePlugin = require('offline-plugin');
+
 module.exports = {
     devtool: 'cheap-module-eval-source-map',
     entry: [

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,6 +1,8 @@
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
+var OfflinePlugin = require('offline-plugin');
+
 module.exports = {
     devtool: 'source-map',
 

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -32,5 +32,6 @@ module.exports = {
                 warnings: false,
             },
         }),
+        new OfflinePlugin(),
     ],
 };

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -34,6 +34,11 @@ module.exports = {
                 warnings: false,
             },
         }),
-        new OfflinePlugin(),
+        new OfflinePlugin({
+            ServiceWorker:{
+                entry: 'sw.js',
+                events: true,
+            }
+        }),
     ],
 };

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -35,9 +35,12 @@ module.exports = {
             },
         }),
         new OfflinePlugin({
+            updateStrategy: 'changed',
+            autoUpdate: 1000 * 60 * 60 * 1, //1h
             ServiceWorker:{
                 entry: 'sw.js',
                 events: true,
+                navigateFallbackURL: '/',
             }
         }),
     ],


### PR DESCRIPTION
Deploy and integrate a Service Worker for the APP.

By default it remains 1h //due to development purposes

Also provide a way to intercept `push` messages using our own SW handler.

Finally, it handles new version updates, and reload the window once all changes are applied (when the client updates the navigation flow).

Fix #208 Integrate Service Workers
Fix #209 Handle version updates using SW
Fix #210 Handle new tab clicks
