### PR TITLE
BUG multiple attachments while exporting Elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "less": "^2.7.2",
     "less-loader": "^2.2.3",
     "lodash": "^4.17.4",
-    "material-ui": "^0.18.1",
+    "material-ui": "^0.18.7",
     "mocha": "^3.2.0",
     "morgan": "^1.7.0",
     "node-sass": "^4.2.0",

--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -336,7 +336,7 @@ export function fetchAggregations(a_filter=null, initial=false) {
 export function exportElement(a_filter=null, initial=false) {
     return (dispatch) => {
         dispatch(fetchElementsExportRequest(initial));
-        ask_the_api("elements.export", a_filter);
+        ask_the_api("elements.export", a_filter, window.socket.id);
     };
 }
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -125,14 +125,16 @@ export class Connection extends Component {
 			})
 
 			.on('elements.file', (content) => {
-				console.debug('[Websocket] Exported element received');
+                console.log(window.socket.id, content.client_id);
+                if (window.socket.id == content.client_id) {
+    				console.debug('[Websocket] Exported element received');
+                    const file_buffer = Buffer.from(content.result);
+                    const file = new Blob( [ file_buffer ]);
+                    FileSaver.saveAs(file, content.filename);
 
-                const file_buffer = Buffer.from(content.result);
-                const file = new Blob( [ file_buffer ]);
-                FileSaver.saveAs(file, content.filename);
-
-                if (!content.silent) {
-                    this.prepareNotification(content, "XLS document exported");;
+                    if (!content.silent) {
+                        this.prepareNotification(content, "XLS document exported");;
+                    }
                 }
 			})
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -89,6 +89,9 @@ export class Connection extends Component {
         //initialize the connection
 		const initial=true;
 
+        window.socket._callbacks = Object.assign({})
+
+
 		//listen events!
 		window.socket
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -89,8 +89,10 @@ export class Connection extends Component {
         //initialize the connection
 		const initial=true;
 
-        window.socket._callbacks = Object.assign({})
-
+        // Preventive clean'up of already set Listeners
+        if (window.socket.connected && Object.keys(window.socket._callbacks).length > 0 ) {
+            window.socket.removeAllListeners()
+        }
 
 		//listen events!
 		window.socket
@@ -128,7 +130,7 @@ export class Connection extends Component {
 			})
 
 			.on('elements.file', (content) => {
-                console.log(window.socket.id, content.client_id);
+                // Prepare the attachment just for the requester client
                 if (window.socket.id == content.client_id) {
     				console.debug('[Websocket] Exported element received');
                     const file_buffer = Buffer.from(content.result);


### PR DESCRIPTION
## Solved BUG multiple attachments while exporting Elements

It provides a fix for the multiple attachments (duplicated) downloading while trying to export an Element.

It's related to a duplicated socket event listeners and a non managed origin of the requests.

### Fixed issues

- Fix  #229 BUG n-duplicated socket listeners
- Fix #228 BUG downloading attachments 
