### PR TITLE
Pending elements synchronization

### DIFF
--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -540,3 +540,29 @@ export function overrideVersion(response, initial) {
     }
     return {};
 }
+
+
+
+
+
+/**************
+Session synch !
+**************/
+
+export function synchronizePendingElementsRequest() {
+    const message = "(re)Processing proposal";
+
+    return {
+        type: RUN_ELEMENT_REQUEST,
+        payload: {
+            message,
+        },
+    };
+}
+
+export function synchronizePendingElements(a_filter=null) {
+    return (dispatch) => {
+        dispatch(synchronizePendingElementsRequest());
+        ask_the_api("session.sync", a_filter);
+    };
+}

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -244,6 +244,7 @@ export class Connection extends Component {
             })
 
 
+
         //////////////
         // SETTINGS //
         //////////////
@@ -267,7 +268,7 @@ export class Connection extends Component {
         ////////////////////
 
             .on('connect', () => {
-                console.debug('Connected');
+                console.debug('[Websocket] Connected');
 
                 this.cleanNotifications();
                 this.prepareNotification({
@@ -293,7 +294,7 @@ export class Connection extends Component {
             })
 
             .on('auth.logout', (content) => {
-                console.debug('Enforced logout from the API');
+                console.debug('[Websocket] Enforced logout from the API');
                 this.prepareNotification(content);
 
                 setTimeout(() => {
@@ -302,7 +303,7 @@ export class Connection extends Component {
             })
 
             .on('disconnect', () => {
-                console.debug('Disconnected');
+                console.debug('[Websocket] Disconnected');
 
                 this.cleanNotifications();
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -12,6 +12,9 @@ var NotificationSystem = require('react-notification-system');
 
 var FileSaver = require('../../../node_modules/file-saver/FileSaver.min.js');
 
+import { localized_time } from '../../constants'
+
+
 function mapStateToProps(state) {
     return {
     };
@@ -203,17 +206,17 @@ export class Connection extends Component {
         // PROFILE //
         /////////////
 
-        .on('profile.override', (content) => {
-            console.debug('[Websocket] Profile received');
-            this.props.overrideProfile(content, initial);
+            .on('profile.override', (content) => {
+                console.debug('[Websocket] Profile received');
+                this.props.overrideProfile(content, initial);
 
-            if (!content.silent) {
-                if (content.clean_all)
-                    this.cleanNotifications();
+                if (!content.silent) {
+                    if (content.clean_all)
+                        this.cleanNotifications();
 
-                this.prepareNotification(content);;
-            }
-        })
+                    this.prepareNotification(content);;
+                }
+            })
 
 
 
@@ -221,34 +224,34 @@ export class Connection extends Component {
         // PROFILE //
         /////////////
 
-        .on('version.override', (content) => {
-            console.debug('[Websocket] Version received');
-            this.props.overrideVersion(content, initial);
+            .on('version.override', (content) => {
+                console.debug('[Websocket] Version received');
+                this.props.overrideVersion(content, initial);
 
-            if (!content.silent) {
-                if (content.clean_all)
-                    this.cleanNotifications();
+                if (!content.silent) {
+                    if (content.clean_all)
+                        this.cleanNotifications();
 
-                this.prepareNotification(content);;
-            }
-        })
+                    this.prepareNotification(content);;
+                }
+            })
 
 
         //////////////
         // SETTINGS //
         //////////////
 
-        .on('sources.override', (content) => {
-            console.debug('[Websocket] Sources received');
-            this.props.overrideSources(content, initial);
+            .on('sources.override', (content) => {
+                console.debug('[Websocket] Sources received');
+                this.props.overrideSources(content, initial);
 
-            if (!content.silent) {
-                if (content.clean_all)
-                    this.cleanNotifications();
+                if (!content.silent) {
+                    if (content.clean_all)
+                        this.cleanNotifications();
 
-                this.prepareNotification(content);;
-            }
-        })
+                    this.prepareNotification(content);;
+                }
+            })
 
 
 
@@ -265,6 +268,9 @@ export class Connection extends Component {
                     title: 'Connected!',
                     message: 'Connection established!',
                 });
+
+                const todayDate = localized_time();
+                this.props.synchronizePendingElements(todayDate.unix());
             })
 
             .on('disconnect', () => {

--- a/src/components/Logout.js
+++ b/src/components/Logout.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { browserHistory } from 'react-router';
+import * as actionCreators from '../actions/auth';
+
+function mapStateToProps(state) {
+    return {
+        isAuthenticated: state.auth.isAuthenticated,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return bindActionCreators(actionCreators, dispatch);
+}
+
+export function requireUnauthentication(Component) {
+
+    class requireUnauthentication extends React.Component {
+
+        constructor(props) {
+            super(props);
+        }
+
+        componentWillMount() {
+            this.logout();
+        }
+
+        componentWillReceiveProps(nextProps) {
+            this.logout();
+        }
+
+        logout() {
+            this.props.logoutAndRedirect();
+        }
+
+        render() {
+            return (
+                <div>
+                </div>
+            );
+        }
+    }
+
+    requireUnauthentication.propTypes = {
+        logoutAndRedirect: PropTypes.func,
+    };
+
+    return connect(mapStateToProps, mapDispatchToProps)(requireUnauthentication);
+}

--- a/src/reducers/orakwlum.js
+++ b/src/reducers/orakwlum.js
@@ -17,6 +17,7 @@ const initialState = {
     profile: {},
     sources: {},
     version: {},
+    sync: {},
 };
 
 export default createReducer(initialState, {

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,6 +25,7 @@ import Concatenator from './components/ElementsConcatenation';
 import { DetermineAuth } from './components/DetermineAuth';
 import { requireAuthentication } from './components/AuthenticatedComponent';
 import { requireNoAuthentication } from './components/notAuthenticatedComponent';
+import { requireUnauthentication } from './components/Logout';
 
 
 export default (
@@ -33,6 +34,8 @@ export default (
         <Route path="login" component={requireNoAuthentication(LoginView)} />
         <Route path="register" component={requireNoAuthentication(RegisterView)} />
         <Route path="home" component={requireNoAuthentication(HomeContainer)} />
+
+        <Route name="logout" path="logout" component={requireUnauthentication()} />
         <Route path="history" component={requireAuthentication(Analytics)} />
         <Route path="aggregations" component={requireAuthentication(Aggregations)} />
         <Route path="profile"   component={requireAuthentication(Profile)} />
@@ -53,6 +56,7 @@ export default (
         <Route name="Element" path="elements/:elementID" component={requireAuthentication(Element)} />
         <Route name="ElementsConcatenation" path="elements/concatenate/:elementsList" component={requireAuthentication(Concatenator)} />
         <Route name="ElementsComparator" path="elements/compare/:elementA/:elementB" component={requireAuthentication(Comparator)} />
+
 
         <Route path="*" component={NotFound} />
 


### PR DESCRIPTION
Pending elements are now synchronized when the connection is established.

The frontend send to the API a message with the last synchronized timestamp, and the API start the sync process sending the new elements.

Also, solves the bug handling invalid sessions (#247)

Fix #240 Synchronize pending elements
Fix #247 BUG at invalid session handling


