### PR TITLE
Tuned predictions synchronization

### DIFF
--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -428,7 +428,7 @@ export function saveTunedValuesReducer(id, modifications) {
     const modifications_to_update = {
         [id]: modifications,
     }
-    
+
     return {
         type: UPDATE_TUNED_VALUES,
         payload: {
@@ -439,8 +439,12 @@ export function saveTunedValuesReducer(id, modifications) {
 
 export function saveTunedValues(id, modifications) {
     return (dispatch) => {
+        console.debug("Saving modifications", id, modifications)
+        //Save locally
         dispatch(saveTunedValuesReducer(id, modifications));
-        console.log(id, modifications)
+        
+        //Save at API
+        ask_the_api("elements.modifications.update", {id: id, modifications: modifications});
     };
 }
 

--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -437,14 +437,25 @@ export function saveTunedValuesReducer(id, modifications) {
     };
 }
 
+export function reduceModifications(response) {
+    if (!response.error){
+        const the_result = JSON.parse(response.result);
+        const the_id = the_result.element_id;
+
+
+        return saveTunedValuesReducer(the_id, the_result);
+    }
+    return {};
+}
+
 export function saveTunedValues(id, modifications) {
     return (dispatch) => {
         console.debug("Saving modifications", id, modifications)
         //Save locally
         dispatch(saveTunedValuesReducer(id, modifications));
-        
+
         //Save at API
-        ask_the_api("elements.modifications.update", {id: id, modifications: modifications});
+        ask_the_api("modifications.update", {"element_id": id, modifications: modifications});
     };
 }
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -43,7 +43,7 @@ export class Connection extends Component {
         if (content && 'message' in content) {
             //Initialize a new message based on the provided one
             let the_message = {
-                ...{},
+                ...{autoDismiss: 10},
                 ...content,
             }
 

--- a/src/components/Connection/index.js
+++ b/src/components/Connection/index.js
@@ -148,11 +148,26 @@ export class Connection extends Component {
                     FileSaver.saveAs(file, content.filename);
 
                     if (!content.silent) {
-                        this.prepareNotification(content, "XLS document exported");;
+                        this.prepareNotification(content, "XLS document exported");
                     }
                 }
 			})
 
+
+
+
+        ///////////////////
+        // MODIFICATIONS //
+        ///////////////////
+
+			.on('modifications.extend', (content) => {
+				console.debug('[Websocket] Modifications to extend received');
+				this.props.reduceModifications(content);
+
+                if (!content.silent) {
+                    this.prepareNotification(content, "Modifications updated");
+                }
+			})
 
 
         //////////////////


### PR DESCRIPTION
### Tuned predictions synchronization

Following #263, it integrates the tuned values of a Proposal with the API and the Store.

With it, all changes can be saved asking the Element action button "SAVE":
- Changes applied to the local store
- Ask API to apply changes

At render time, the changes are identified and applied above the predicted values.

It creates an isolated store inside the main orakwlum reducer called "modifications". It's an object with the related element_id key. For each modification, an object with the aggregationIDs as key, and another object with each hour, and the dict of modifications by aggregate. Something like:
```
modifications = {
    "001" : {                             //aggregation with ID 001
        "0": {                            //hour with ID 0
             "20A": 500,                  //aggregate with ID 20A
             "30A": 200,
         }
    }
}
```

#### Provided changes
- Notification messages now are showed 10' by default (#234)
- New/updated modifications are synchronized at session initialization (#266)
- Updated modifications are triggered to the API once "Save" button is asked (#265)

Fix #234 UX extend messages render time
Fix #266 Synchronize updated modifications at startup
Fix #265 Synchronize modifications with the API


