### PR TITLE
Losses integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,8 +122,8 @@
     "socket.io-client": "latest",
     "redux-persist": "latest",
     "react-notification-system": "latest",
-    "localforage": "latest",
-    "deepmerge": "latest"
+    "localforage": "^1.5.0",
+    "deepmerge": "^1.5.2"
   },
   "dependencies": {
     "binding": "^3.0.3",

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -160,6 +160,7 @@ export class Elementt extends Component {
         this.state = {
             proposal: props.proposal,
             proposalTable: false,
+            withLosses: false,
             aggregations: props.aggregations,
             aggregationSelected: props.aggregations[0].id,
             message_text: props.message_text,
@@ -280,6 +281,12 @@ export class Elementt extends Component {
 
     toogleElementRender = (event, status) => {
         this.setState({proposalTable: status, message_open: false});
+        this.animateChart = false;
+    };
+
+    // Handle if a Element must be rendered with Losses or just measures
+    toogleElementTotals = (event, status) => {
+        this.setState({withLosses: status, message_open: false});
         this.animateChart = false;
     };
 
@@ -566,6 +573,7 @@ export class Elementt extends Component {
         const {notes} = proposal;
 
         const proposalTable = this.state.proposalTable;
+        const withLosses = this.state.withLosses;
 
         const historical = (proposal.historical == false)
             ? false
@@ -752,6 +760,36 @@ export class Elementt extends Component {
                 </div>
 }
         </div>)
+
+        const LossesHelp = "Render an Element with their related losses or just their measures"
+
+        // The Element graph toogle! //to switch between table and chart
+        const withLossesToggle = <div className="col-xs-offset-0 col-xs-6 col-sm-offset-0 col-sm-3 col-md-2 col-md-offset-0 col-lg-offset-0 col-lg-2" style={styles.to_ri}>
+            {(withLosses)
+                ? <div id="togglePicture" className="row" style={styles.aggregationsCenter}>
+                        <div className="col-xs-2" style={styles.labelToggle}>
+                            Measures
+                        </div>
+                        <div id="toogleElement" className="col-xs-3">
+                            <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
+                        </div>
+                        <div className="col-xs-2" style={styles.toggle}>
+                            <b>Totals</b>
+                        </div>
+                    </div>
+                : <div id="togglePicture" className="row" style={styles.aggregationsCenter}>
+                    <div className="col-xs-2" style={styles.labelToggle}>
+                        <b>Measures</b>
+                    </div>
+                    <div id="toogleElement" className="col-xs-3">
+                        <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
+                    </div>
+                    <div className="col-xs-2" style={styles.toggle}>
+                        Totals
+                    </div>
+                </div>
+}
+        </div>
 
         const adaptedElement = Object.assign({}, proposal, {
             start_date: start_date.toDate(),
@@ -982,6 +1020,7 @@ export class Elementt extends Component {
                     {proposalAggregations}
 
                     {proposalPictureToggle}
+                    {withLossesToggle}
                 </div>
 
                 <CardText>

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -239,6 +239,12 @@ export class Elementt extends Component {
             this.summary = (prediction.summary != undefined)
                 ? prediction.summary
                 : null;
+
+            //Identify the scale
+            this.scale = 0
+            const max_total = ("max_total" in this.summary)?this.summary["max_total"]:0;
+            const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:0;
+            this.scale = Math.max(max_total, max_total_with_losses);
         }
     }
 
@@ -571,7 +577,6 @@ export class Elementt extends Component {
         const proposal = this.props.proposal;
         this.prepareData(this.props.proposal.prediction, this.props.aggregations)
 
-
         const {notes} = proposal;
 
         const {proposalTable, withLosses} = this.state;
@@ -881,7 +886,7 @@ export class Elementt extends Component {
             if (withPicture && prediction && Object.keys(prediction).length > 0)
                 proposalPicture = (proposalTable)
                     ? <ElementTable stacked={true} data={this.data[aggregationSelected]} components={this.components[aggregationSelected]} height={500} unit={"kWh"}/>
-                    : <ElementGraph stacked={true} data={this.data[aggregationSelected]} components={this.components[aggregationSelected]} height={500} animated={this.animateChart} unit={"kWh"}/>
+                    : <ElementGraph stacked={true} data={this.data[aggregationSelected]} components={this.components[aggregationSelected]} height={500} animated={this.animateChart} unit={"kWh"} scale={this.scale}/>
         }
 
         const disableDetail = (element_type == "concatenation")

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -246,7 +246,8 @@ export class Elementt extends Component {
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
             let scalator_const = 1000;
-            this.scale = Math.max(Math.ceil(max_total / scalator_const)*scalator_const, Math.ceil(max_total_with_losses/scalator_const)*scalator_const );
+            const max_of_pair = Math.max(max_total, max_total_with_losses);
+            this.scale = Math.ceil(max_of_pair / scalator_const) * scalator_const;
         }
     }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -245,8 +245,8 @@ export class Elementt extends Component {
             const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
-            let scalator_const = 1000;
             const max_of_pair = Math.max(max_total, max_total_with_losses);
+            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10));
             this.scale = Math.ceil(max_of_pair / scalator_const) * scalator_const;
         }
     }

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -205,13 +205,15 @@ export class Elementt extends Component {
     }
 
     prepareData = (prediction, aggregations) => {
+        const {withLosses} = this.state;
+
         if (prediction && Object.keys(prediction).length > 0) {
 
             for (let [key, an_agg]of Object.entries(aggregations)) {
                 const current_agg_id = an_agg.id;
 
                 //The Prediction of current aggregation
-                const predictionAdapted = adaptProposalData(prediction['result']);
+                const predictionAdapted = adaptProposalData(prediction['result'], withLosses);
                 const current = predictionAdapted[current_agg_id];
 
                 //Initialize modifications for current aggregation just if empty
@@ -572,8 +574,7 @@ export class Elementt extends Component {
 
         const {notes} = proposal;
 
-        const proposalTable = this.state.proposalTable;
-        const withLosses = this.state.withLosses;
+        const {proposalTable, withLosses} = this.state;
 
         const historical = (proposal.historical == false)
             ? false
@@ -766,22 +767,22 @@ export class Elementt extends Component {
         // The Element graph toogle! //to switch between table and chart
         const withLossesToggle = <div className="col-xs-offset-0 col-xs-6 col-sm-offset-0 col-sm-3 col-md-2 col-md-offset-0 col-lg-offset-0 col-lg-2" style={styles.to_ri}>
             {(withLosses)
-                ? <div id="togglePicture" className="row" style={styles.aggregationsCenter}>
+                ? <div id="toggleLosses" className="row" style={styles.aggregationsCenter}>
                         <div className="col-xs-2" style={styles.labelToggle}>
                             Measures
                         </div>
-                        <div id="toogleElement" className="col-xs-3">
+                        <div id="toogleTotals" className="col-xs-3">
                             <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
                         </div>
                         <div className="col-xs-2" style={styles.toggle}>
                             <b>Totals</b>
                         </div>
                     </div>
-                : <div id="togglePicture" className="row" style={styles.aggregationsCenter}>
+                : <div id="toggleLosses" className="row" style={styles.aggregationsCenter}>
                     <div className="col-xs-2" style={styles.labelToggle}>
                         <b>Measures</b>
                     </div>
-                    <div id="toogleElement" className="col-xs-3">
+                    <div id="toogleTotals" className="col-xs-3">
                         <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
                     </div>
                     <div className="col-xs-2" style={styles.toggle}>

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -242,8 +242,8 @@ export class Elementt extends Component {
 
             //Identify the scale
             this.scale = 0
-            const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
-            const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
+            const max_total = ("max_total" in this.summary)?this.summary["max_total"]:0;
+            const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:0;
 
             //Fetch the max to define the scale and the order of magnitude
             const max_of_pair = Math.max(max_total, max_total_with_losses);

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -242,9 +242,13 @@ export class Elementt extends Component {
 
             //Identify the scale
             this.scale = 0
-            const max_total = ("max_total" in this.summary)?this.summary["max_total"]:0;
-            const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:0;
-            this.scale = Math.max(max_total, max_total_with_losses);
+            const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
+            const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
+
+            const max_beautiful = Math.ceil((max_total_with_losses)/1000)*1000;
+
+            this.scale = (withLosses)? (max_beautiful - max_total_with_losses).toFixed(1): max_beautiful - max_total;
+            console.log("scale",this.scale);
         }
     }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -245,10 +245,7 @@ export class Elementt extends Component {
             const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
-            const max_beautiful = Math.ceil((max_total_with_losses)/1000)*1000;
-
-            this.scale = (withLosses)? (max_beautiful - max_total_with_losses).toFixed(1): max_beautiful - max_total;
-            console.log("scale",this.scale);
+            this.scale = Math.max(Math.ceil(max_total / 100)*100, Math.ceil(max_total_with_losses/100)*100 );
         }
     }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -160,7 +160,7 @@ export class Elementt extends Component {
         this.state = {
             proposal: props.proposal,
             proposalTable: false,
-            withLosses: false,
+            withLosses: true,
             aggregations: props.aggregations,
             aggregationSelected: props.aggregations[0].id,
             message_text: props.message_text,
@@ -920,8 +920,9 @@ export class Elementt extends Component {
                         avg_info={{
                             'average': this.average[aggregationSelected],
                             'data': this.data[aggregationSelected],
-                            'components': this.components[aggregationSelected]
+                            'components': this.components[aggregationSelected],
                         }}
+                        withLosses={withLosses}
                     />
                 </div>
             </div>;

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -245,7 +245,8 @@ export class Elementt extends Component {
             const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
-            this.scale = Math.max(Math.ceil(max_total / 100)*100, Math.ceil(max_total_with_losses/100)*100 );
+            let scalator_const = 1000;
+            this.scale = Math.max(Math.ceil(max_total / scalator_const)*scalator_const, Math.ceil(max_total_with_losses/scalator_const)*scalator_const );
         }
     }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -777,7 +777,7 @@ export class Elementt extends Component {
         const LossesHelp = "Render an Element with their related losses or just their measures"
 
         // The Element graph toogle! //to switch between table and chart
-        const withLossesToggle = <div className="col-xs-offset-0 col-xs-6 col-sm-offset-0 col-sm-3 col-md-2 col-md-offset-0 col-lg-offset-0 col-lg-2" style={styles.to_ri}>
+        const withLossesToggle = (withPicture) && <div className="col-xs-offset-0 col-xs-6 col-sm-offset-0 col-sm-3 col-md-2 col-md-offset-0 col-lg-offset-0 col-lg-2" style={styles.to_ri}>
             {(withLosses)
                 ? <div id="toggleLosses" className="row" style={styles.aggregationsCenter}>
                         <div className="col-xs-2" style={styles.labelToggle}>

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -246,7 +246,7 @@ export class Elementt extends Component {
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
             const max_of_pair = Math.max(max_total, max_total_with_losses);
-            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10))/10;
+            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10 + 0.000000001))/10;
             this.scale = Math.ceil(max_of_pair / scalator_const) * scalator_const;
         }
     }

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -246,7 +246,7 @@ export class Elementt extends Component {
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
             const max_of_pair = Math.max(max_total, max_total_with_losses);
-            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10));
+            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10))/10;
             this.scale = Math.ceil(max_of_pair / scalator_const) * scalator_const;
         }
     }

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -245,9 +245,13 @@ export class Elementt extends Component {
             const max_total = ("max_total" in this.summary)?this.summary["max_total"]:26988;
             const max_total_with_losses = ("max_total_with_losses" in this.summary)?this.summary["max_total_with_losses"]:31241.9;
 
+            //Fetch the max to define the scale and the order of magnitude
             const max_of_pair = Math.max(max_total, max_total_with_losses);
-            let scalator_const = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10 + 0.000000001))/10;
-            this.scale = Math.ceil(max_of_pair / scalator_const) * scalator_const;
+            //Calc the order of magnitude using log and pow
+            const order_of_magnitude = Math.pow(10, Math.floor(Math.log(max_of_pair) / Math.LN10 + 0.000000001))/10;
+
+            //Round UP the scale to the next beautiful number based on current order of magnitude
+            this.scale = Math.ceil(max_of_pair / order_of_magnitude) * order_of_magnitude;
         }
     }
 

--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -781,24 +781,22 @@ export class Elementt extends Component {
             {(withLosses)
                 ? <div id="toggleLosses" className="row" style={styles.aggregationsCenter}>
                         <div className="col-xs-2" style={styles.labelToggle}>
-                            Measures
                         </div>
                         <div id="toogleTotals" className="col-xs-3">
                             <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
                         </div>
                         <div className="col-xs-2" style={styles.toggle}>
-                            <b>Totals</b>
+                            <b>Losses</b>
                         </div>
                     </div>
                 : <div id="toggleLosses" className="row" style={styles.aggregationsCenter}>
                     <div className="col-xs-2" style={styles.labelToggle}>
-                        <b>Measures</b>
                     </div>
                     <div id="toogleTotals" className="col-xs-3">
                         <Toggle onToggle={this.toogleElementTotals} style={styles.toggle} toggled={withLosses} title={LossesHelp}/>
                     </div>
                     <div className="col-xs-2" style={styles.toggle}>
-                        Totals
+                        Losses
                     </div>
                 </div>
 }

--- a/src/components/ElementDetail/index.js
+++ b/src/components/ElementDetail/index.js
@@ -44,7 +44,7 @@ export class ElementDetail extends Component {
 
         const total_cups = data.cups;
         const energy_total = data.energy_total;
-        const energy_total_with_losses = data.energy_total;
+        const energy_total_with_losses = data.energy_with_losses_total;
         const total_invoices = data.invoices;
         const origins_data = data.origins;
         const tariffs_data = data.tariffs;

--- a/src/components/ElementDetail/index.js
+++ b/src/components/ElementDetail/index.js
@@ -50,7 +50,7 @@ export class ElementDetail extends Component {
         const tariffs_data = data.tariffs;
 
         const expectedEnergy = (withLosses)? "energy_total" : "energy";
-        const expectedTotal = (withLosses)? energy_total : energy_total_with_losses;
+        const expectedTotal = (withLosses)? energy_total_with_losses : energy_total;
 
         //Prepare CUPS count
         const num_cups = (total_cups) &&
@@ -85,7 +85,7 @@ export class ElementDetail extends Component {
                 const entry = origins_data[origin];
 
                 const component_name = origin;
-                const component_value =  parseFloat(entry[expectedEnergy]).toFixed(digitsToRound);
+                const component_value =  Math.round(parseFloat(entry[expectedEnergy]));
                 const component_subvalue =  entry['count'];
                 const original_position =  entry['order'];
 
@@ -122,7 +122,7 @@ export class ElementDetail extends Component {
                 const entry = tariffs_data[tariff];
 
                 const component_name = tariff;
-                const component_value =  (parseFloat(entry[expectedEnergy]));
+                const component_value =  Math.round(parseFloat(entry[expectedEnergy]));
 
                 const component_subvalue =  entry['count'];
                 const original_position =  entry['order'];

--- a/src/components/ElementDetail/index.js
+++ b/src/components/ElementDetail/index.js
@@ -36,8 +36,11 @@ export class ElementDetail extends Component {
     }
 
     render() {
-        const data = this.props.data;
-        const avg_info = this.props.avg_info;
+        const {withLosses, data, avg_info} = this.props;
+        const expectedEnergy = (withLosses)? "energy_total" : "energy";
+        const expectedAvg = (withLosses)? "average_total" : "average";
+
+        const digitsToRound = 2;
 
         //open it by default
         const open = (this.props.open)?this.props.open:true;
@@ -71,7 +74,6 @@ export class ElementDetail extends Component {
                 />
             );
 
-
         //handle invoice types
         const invoice_types = (origins_data) &&
             Object.keys(origins_data).sort(
@@ -82,7 +84,7 @@ export class ElementDetail extends Component {
                 const entry = origins_data[origin];
 
                 const component_name = origin;
-                const component_value =  entry['energy'];
+                const component_value =  parseFloat(entry[expectedEnergy]).toFixed(digitsToRound);
                 const component_subvalue =  entry['count'];
                 const original_position =  entry['order'];
 
@@ -119,7 +121,8 @@ export class ElementDetail extends Component {
                 const entry = tariffs_data[tariff];
 
                 const component_name = tariff;
-                const component_value =  entry['energy'];
+                const component_value =  parseFloat(entry[expectedEnergy]).toFixed(digitsToRound);
+
                 const component_subvalue =  entry['count'];
                 const original_position =  entry['order'];
 
@@ -194,6 +197,7 @@ export class ElementDetail extends Component {
 ElementDetail.propTypes = {
     data: PropTypes.object.isRequired,
     open: PropTypes.bool,
+    withLosses: PropTypes.bool,
     colors: PropTypes.object,
     avg_info: PropTypes.object,
 };

--- a/src/components/ElementDetail/index.js
+++ b/src/components/ElementDetail/index.js
@@ -37,9 +37,6 @@ export class ElementDetail extends Component {
 
     render() {
         const {withLosses, data, avg_info} = this.props;
-        const expectedEnergy = (withLosses)? "energy_total" : "energy";
-        const expectedAvg = (withLosses)? "average_total" : "average";
-
         const digitsToRound = 2;
 
         //open it by default
@@ -47,9 +44,13 @@ export class ElementDetail extends Component {
 
         const total_cups = data.cups;
         const energy_total = data.energy_total;
+        const energy_total_with_losses = data.energy_total;
         const total_invoices = data.invoices;
         const origins_data = data.origins;
         const tariffs_data = data.tariffs;
+
+        const expectedEnergy = (withLosses)? "energy_total" : "energy";
+        const expectedTotal = (withLosses)? energy_total : energy_total_with_losses;
 
         //Prepare CUPS count
         const num_cups = (total_cups) &&
@@ -96,7 +97,7 @@ export class ElementDetail extends Component {
                         title={component_name}
                         value={component_value + " kWh"}
                         subvalue={"#" + component_subvalue}
-                        total={energy_total}
+                        total={expectedTotal}
                         percentage={true}
                         small={true}
                     />
@@ -121,10 +122,12 @@ export class ElementDetail extends Component {
                 const entry = tariffs_data[tariff];
 
                 const component_name = tariff;
-                const component_value =  parseFloat(entry[expectedEnergy]).toFixed(digitsToRound);
+                const component_value =  (parseFloat(entry[expectedEnergy]));
 
                 const component_subvalue =  entry['count'];
                 const original_position =  entry['order'];
+
+                console.log(expectedTotal);
 
                 //const color = colors[original_position];  //use API order field
                 const color = colors[i];
@@ -135,7 +138,7 @@ export class ElementDetail extends Component {
                         title={ (component_name!="")?component_name:"Empty"}
                         value={component_value + " kWh"}
                         subvalue={"#" + component_subvalue}
-                        total={energy_total}
+                        total={expectedTotal}
                         percentage={true}
                         small={true}
                         color={color}

--- a/src/components/ElementGraph/index.js
+++ b/src/components/ElementGraph/index.js
@@ -95,8 +95,6 @@ export class ElementGraph extends Component {
         const components = this.props.components;
         const scale = (this.props.scale)?parseFloat(this.props.scale) : "auto";
 
-        console.log("MAX", scale);
-
         const stacked = (this.props.stacked)?"1":null;
 
         const height = (this.props.height)?this.props.height:500;

--- a/src/components/ElementGraph/index.js
+++ b/src/components/ElementGraph/index.js
@@ -93,7 +93,9 @@ export class ElementGraph extends Component {
     render() {
         const data = this.props.data;
         const components = this.props.components;
+        const scale = (this.props.scale)?"dataMax + " + String(this.props.scale) : "auto";
 
+        console.log("MAX", scale);
 
         const stacked = (this.props.stacked)?"1":null;
 
@@ -190,7 +192,7 @@ export class ElementGraph extends Component {
               const xaxis = <XAxis dataKey="name" label={"Hour"}/>;
               const xaxisLite = <XAxis dataKey="name"/>;
 
-              const yaxis = <YAxis label={unit}/>;
+              const yaxis = (scale != null)? <YAxis label={unit} type={"number"} domain={[0, scale]}/> : <YAxis label={unit}/>;
               const yaxisLite = <YAxis/>;
 
               const grid = <CartesianGrid strokeDasharray="3 3"/>;

--- a/src/components/ElementGraph/index.js
+++ b/src/components/ElementGraph/index.js
@@ -93,7 +93,7 @@ export class ElementGraph extends Component {
     render() {
         const data = this.props.data;
         const components = this.props.components;
-        const scale = (this.props.scale)?"dataMax + " + String(this.props.scale) : "auto";
+        const scale = (this.props.scale)?parseFloat(this.props.scale) : "auto";
 
         console.log("MAX", scale);
 

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -9,10 +9,15 @@ function prepareDayAndHourString(timestamp) {
     return localized_time(timestamp).format(day_month_format + " " + hour_unique_format);
 }
 
-export function adaptProposalData(prediction) {
+export function adaptProposalData(prediction, withLosses=false) {
     let result={};
 
+    // Define expected Amount an AVG depending on the withLosses flag
+    const expectedAmount = (withLosses)? "total" : "amount";
+    const expectedAvg = (withLosses)? "average_total" : "average";
+
     const proposalData = prediction;
+    const digitsToRound = 2;
 
     Object.keys(proposalData).map( function(current_aggregation, j) {
             const aggregation = proposalData[current_aggregation];
@@ -38,8 +43,8 @@ export function adaptProposalData(prediction) {
             const the_sum = aggregation['result'];
             the_sum.map( function(entry, i) {
                 const hour=entry['hour'];
-                const amount=entry['amount'];
-                const avg=entry['average'].toFixed(4);
+                const amount=entry[expectedAmount].toFixed(digitsToRound);
+                const avg=entry[expectedAvg].toFixed(digitsToRound);
 
                 const title=entry['title'];
 
@@ -48,14 +53,14 @@ export function adaptProposalData(prediction) {
                     tmp_result[hour]={total: 0, name: hour};
 
                 tmp_result[hour][title] = amount;
-                tmp_result[hour]["total"] = parseInt(tmp_result[hour]["total"]) + parseInt(amount);
+                tmp_result[hour]["total"] = (parseInt(tmp_result[hour]["total"]) + parseInt(amount)).toFixed(digitsToRound);
 
                 // initialize average hour with an empty dict
                 if (!tmp_average[hour])
                     tmp_average[hour]={total: 0, name: hour};
 
                 tmp_average[hour][title] = avg;
-                tmp_average[hour]["total"] = parseInt(tmp_average[hour]["total"]) + parseInt(avg);
+                tmp_average[hour]["total"] = (parseInt(tmp_average[hour]["total"]) + parseInt(avg)).toFixed(digitsToRound);
 
                 result[current_aggregation]['components'][title] = {
                     'title': title,

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -25,9 +25,9 @@ export default class SettingsView extends React.Component {
     componentDidMount() {
         const {sources} = this.props;
 
-        if (!sources || Object.keys(sources).length == 0) {
+        //if (!sources || Object.keys(sources).length == 0) {
             this.fetchData();
-        }
+        //}
     }
 
     fetchData() {


### PR DESCRIPTION
It provides Losses Integration to okW and fix an incident while deepmerging elements at localForage

Concretelly, it:
- Add a new toggle inside the Element detail view, desired to activate or not the TOTAL (measures + losses) numbers.
  -  Changes apply to all renders (chart, table) and summary view

Fix #279 Disable sources cache
Fix #280 Add totals toggle
Fix #283 Fix deepmerge and localforage versions