### PR TITLE
Desactivar botones cuando una propuesta está en estad = 'comprado'

### DIFF
--- a/src/components/Element/index.js
+++ b/src/components/Element/index.js
@@ -952,7 +952,7 @@ export class Elementt extends Component {
         const disableExportDetail = (element_type == "comparation" || element_type == "concatenation" )
             ? true
             : false;
-        const boughtProposal = (proposal.status["lite"] != "OK")
+        const boughtProposal = (proposal.status["lite"] == "BUY")
             ? true
             : false;
 


### PR DESCRIPTION
Los botones `PROCES`, `EDIT`, `TUNE`, `SAVE` y `BUY` deben permanecer desactivados si la propuesta que se visualiza ya ha sido comprada.