### PR TITLE
Arreglo del botón de refrescar el calendario

### DIFF
--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -540,6 +540,9 @@ export function deleteElement(element, historical) {
     return (dispatch) => {
         dispatch(deleteElementRequest());
         ask_the_api("elements.delete", element, historical);
+        setTimeout(() => {
+            dispatch(refreshElements());
+        }, 5000)
     };
 }
 


### PR DESCRIPTION
## Objetivos

- El botón `REFRESH` del calendario debe actualizar los elementos correctamente.

## Comportamiento nuevo

- Al pulsar el botón `REFRESH` el calendario se actualiza y se dejan de ver los elementos que ya no existen en la base de datos.

## Checklist
- [x] Test code