### PR TITLE
Se han añadido la opción de realizar acciones sobre múltiples elementos del calendario al mismo tiempo

### DIFF
--- a/src/actions/orakwlum.js
+++ b/src/actions/orakwlum.js
@@ -475,8 +475,12 @@ export function runElement(a_filter=null) {
     };
 }
 
-
-
+export function runElementFromCalendar(a_filter=null) {
+    return (dispatch) => {
+        dispatch(runElementRequest());
+        ask_the_api("elements.run.from.calendar", a_filter);
+    };
+}
 
 export function updateElementlRequest() {
     return {
@@ -549,6 +553,16 @@ export function deleteElement(element, historical) {
     };
 }
 
+export function deleteElementFromCalendar(element, historical) {
+    return (dispatch) => {
+        dispatch(deleteElementRequest());
+        ask_the_api("elements.delete.from.calendar", element, historical);
+        setTimeout(() => {
+            dispatch(fetchElements());
+        }, 5000)
+    };
+}
+
 export function buyElementRequest() {
     return {
         type: BUY_PROPOSAL_REQUEST,
@@ -562,7 +576,12 @@ export function buyElement(element) {
     };
 }
 
-
+export function buyElementFromCalendar(element) {
+    return (dispatch) => {
+        dispatch(buyElementRequest());
+        ask_the_api("elements.buy.from.calendar", element, "elements.buy.from.calendar");
+    };
+}
 
 /********
  PROFILE

--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -237,6 +237,35 @@ export class ElementsDashboard extends Component {
         dispatchNewRoute(location);
     }
 
+    //Dispatch elements delete
+    deleteSelectedElements = () => {
+        const {selectedElements} = this.state;
+
+        if (Object.keys(selectedElements).length >= 1){
+            for ( let [key, value] of Object.entries(selectedElements)) {
+                this.props.deleteElement(key);
+            }
+            this.unselectAllElements()
+            this.toggleMultiElementSelection();
+        }
+    }
+
+    //Dispatch elements reprocess
+    reprocessSelectedElements = () => {
+        const {selectedElements} = this.state;
+
+        if (Object.keys(selectedElements).length >= 1){
+            for ( let [key, value] of Object.entries(selectedElements)) {
+                this.props.runElement(key);
+            }
+            this.unselectAllElements()
+            this.toggleMultiElementSelection();
+            setTimeout(() => {
+                this.refreshData();
+            }, 3000)
+        }
+    }
+
     //Select an element
     selectElement = (count, element, title) => {
         let currentElements = this.state.selectedElements;
@@ -697,6 +726,26 @@ export class ElementsDashboard extends Component {
                             }
                             {selectedElementsList}
                         </List>
+
+                        <div className="row" style={styles.row}>
+                            <div ref="selected_type" className="col-md-4">
+                                <RaisedButton
+                                    label="Reprocess"
+                                    onClick={(event) => this.reprocessSelectedElements()}
+                                    disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="row" style={styles.row}>
+                            <div ref="selected_type" className="col-md-4">
+                                <RaisedButton
+                                    label="Delete"
+                                    onClick={(event) => this.deleteSelectedElements()}
+                                    disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
             }

--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -247,7 +247,7 @@ export class ElementsDashboard extends Component {
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if (value['type'] == 'proposal' && value['status']['lite'] == 'OK'){
                     //TODO: Warning dialog
-                    this.props.buyElement(key);
+                    this.props.buyElementFromCalendar(key);
                 }
             }
             this.unselectAllElements()
@@ -266,7 +266,7 @@ export class ElementsDashboard extends Component {
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if ((value['type'] == 'proposal' && value['status']['lite'] != 'BUY') || value['type'] == 'historical'){
                     //TODO: Warning dialog
-                    this.props.runElement(key);
+                    this.props.runElementFromCalendar(key);
                 }
             }
             this.unselectAllElements()
@@ -285,7 +285,7 @@ export class ElementsDashboard extends Component {
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if ((value['type'] == 'proposal' && value['status']['lite'] != 'RUN') || value['type'] == 'historical'){
                     //TODO: Warning dialog
-                    this.props.deleteElement(key);
+                    this.props.deleteElementFromCalendar(key);
                 }
             }
             this.unselectAllElements()

--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -11,6 +11,8 @@ import Calendar from 'material-ui/DatePicker/Calendar';
 import {dateTimeFormat} from 'material-ui/DatePicker/dateUtils';
 import {List, ListItem} from 'material-ui/List';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
+import RunIcon from 'material-ui/svg-icons/av/play-circle-outline';
+import BuyIcon from 'material-ui/svg-icons/action/work';
 import DatePicker from 'material-ui/DatePicker';
 
 import AutoComplete from 'material-ui/AutoComplete';
@@ -757,29 +759,33 @@ export class ElementsDashboard extends Component {
                         </List>
 
                         <div className="row" style={styles.row}>
-                            <div ref="selected_type" className="col-md-4">
+                            <div ref="selected_type">
                                 <RaisedButton
+                                    icon={<BuyIcon/>}
                                     label="Buy"
+                                    title={"Buy current proposal"}
                                     onClick={(event) => this.buySelectedElements()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />
                             </div>
                         </div>
-
                         <div className="row" style={styles.row}>
-                            <div ref="selected_type" className="col-md-4">
+                            <div ref="selected_type">
                                 <RaisedButton
-                                    label="Reprocess"
+                                    icon={<RunIcon/>}
+                                    label="Process"
+                                    title={"Reprocess current proposal"}
                                     onClick={(event) => this.reprocessSelectedElements()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />
                             </div>
                         </div>
-
                         <div className="row" style={styles.row}>
-                            <div ref="selected_type" className="col-md-4">
+                            <div ref="selected_type">
                                 <RaisedButton
+                                    icon={<DeleteIcon/>}
                                     label="Delete"
+                                    title={"Delete current proposal"}
                                     onClick={(event) => this.deleteSelectedElements()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />

--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -240,13 +240,41 @@ export class ElementsDashboard extends Component {
     }
 
     //Dispatch elements buy
-    buySelectedElements = () => {
-        const {selectedElements} = this.state;
+    buyElementsQuestion = () => {
+        this.creation_dialog['body'] =  <div>
+                                        <p>The selected proposals will change their status to "bought". This process can't be undone.</p>
+                                        <p>Bought proposals can't be processed, edited, tuned or saved.</p>
+                                        <p>Are you sure about to <b>buy those Proposals</b>?</p>
+                                        </div>;
+        this.creation_dialog['title'] = "Buy selected Proposals";
 
+        // The object to handle the creation dialog
+        const creation_dialog_actions = [
+          <FlatButton
+            label="No"
+            primary={true}
+            onClick={() => this.creation_dialog_close()}
+          />,
+          <FlatButton
+            label="Yes"
+            primary={true}
+            keyboardFocused={true}
+            onClick={(event) => this.buySelectedElements()}
+          />,
+        ];
+        this.creation_dialog['actions'] = creation_dialog_actions;
+
+        this.setState({
+            creation_dialog_open: true,
+        });
+    }
+
+    buySelectedElements = () => {
+        this.creation_dialog_close()
+        const {selectedElements} = this.state;
         if (Object.keys(selectedElements).length >= 1){
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if (value['type'] == 'proposal' && value['status']['lite'] == 'OK'){
-                    //TODO: Warning dialog
                     this.props.buyElementFromCalendar(key);
                 }
             }
@@ -259,13 +287,42 @@ export class ElementsDashboard extends Component {
     }
 
     //Dispatch elements reprocess
+    reprocessElementsQuestion = () => {
+        this.creation_dialog['body'] =  <div>
+                                        <p>The selected Elements will be reprocessed. This process can take a while...</p>
+                                        <p>Concatenations, Comparations and Bought proposals can't be reprocessed.</p>
+                                        <p>Are you sure about to&nbsp; <b>reprocess those Elements</b>?</p>
+                                        </div>;
+        this.creation_dialog['title'] = "Reprocess selected Elements";
+
+        // The object to handle the creation dialog
+        const creation_dialog_actions = [
+          <FlatButton
+            label="No"
+            primary={true}
+            onClick={() => this.creation_dialog_close()}
+          />,
+          <FlatButton
+            label="Yes"
+            primary={true}
+            keyboardFocused={true}
+            onClick={(event) => this.reprocessSelectedElements()}
+          />,
+        ];
+        this.creation_dialog['actions'] = creation_dialog_actions;
+
+        this.setState({
+            creation_dialog_open: true,
+        });
+    }
+
     reprocessSelectedElements = () => {
+        this.creation_dialog_close()
         const {selectedElements} = this.state;
 
         if (Object.keys(selectedElements).length >= 1){
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if ((value['type'] == 'proposal' && value['status']['lite'] != 'BUY') || value['type'] == 'historical'){
-                    //TODO: Warning dialog
                     this.props.runElementFromCalendar(key);
                 }
             }
@@ -278,13 +335,42 @@ export class ElementsDashboard extends Component {
     }
 
     //Dispatch elements delete
+    deleteElementsQuestion = () => {
+        this.creation_dialog['body'] =  <div>
+                                        <p>The selected Elements will be deleted. This process can't be undone.</p>
+                                        <p>Concatenations, Comparations and running Elements will not be affected.</p>
+                                        <p>Are you sure about to <b>delete those Elements</b>?</p>
+                                        </div>;
+        this.creation_dialog['title'] = "Delete selected Elements";
+
+        // The object to handle the creation dialog
+        const creation_dialog_actions = [
+          <FlatButton
+            label="No"
+            primary={true}
+            onClick={() => this.creation_dialog_close()}
+          />,
+          <FlatButton
+            label="Yes"
+            primary={true}
+            keyboardFocused={true}
+            onClick={(event) => this.deleteSelectedElements()}
+          />,
+        ];
+        this.creation_dialog['actions'] = creation_dialog_actions;
+
+        this.setState({
+            creation_dialog_open: true,
+        });
+    }
+
     deleteSelectedElements = () => {
+        this.creation_dialog_close()
         const {selectedElements} = this.state;
 
         if (Object.keys(selectedElements).length >= 1){
             for ( let [key, value] of Object.entries(selectedElements)) {
                 if ((value['type'] == 'proposal' && value['status']['lite'] != 'RUN') || value['type'] == 'historical'){
-                    //TODO: Warning dialog
                     this.props.deleteElementFromCalendar(key);
                 }
             }
@@ -764,7 +850,7 @@ export class ElementsDashboard extends Component {
                                     icon={<BuyIcon/>}
                                     label="Buy"
                                     title={"Buy current proposal"}
-                                    onClick={(event) => this.buySelectedElements()}
+                                    onClick={(event) => this.buyElementsQuestion()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />
                             </div>
@@ -775,7 +861,7 @@ export class ElementsDashboard extends Component {
                                     icon={<RunIcon/>}
                                     label="Process"
                                     title={"Reprocess current proposal"}
-                                    onClick={(event) => this.reprocessSelectedElements()}
+                                    onClick={(event) => this.reprocessElementsQuestion()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />
                             </div>
@@ -786,7 +872,7 @@ export class ElementsDashboard extends Component {
                                     icon={<DeleteIcon/>}
                                     label="Delete"
                                     title={"Delete current proposal"}
-                                    onClick={(event) => this.deleteSelectedElements()}
+                                    onClick={(event) => this.deleteElementsQuestion()}
                                     disabled={!multiElementMode || Object.keys(selectedElements).length < 1}
                                 />
                             </div>

--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -295,6 +295,7 @@ export class ElementsDashboard extends Component {
     selectElement = (count, element, title, type, status) => {
         let currentElements = this.state.selectedElements;
         currentElements[element] = {};
+        currentElements[element]['count'] = count
         currentElements[element]['title'] = title
         currentElements[element]['type'] = type
         currentElements[element]['status'] = status
@@ -497,7 +498,7 @@ export class ElementsDashboard extends Component {
                 <ListItem
                     key={key}
                     primaryText={value['title']}
-                    rightIcon={<DeleteIcon onClick={(event) => this.unselectElement(count, key)}/>}
+                    rightIcon={<DeleteIcon onClick={(event) => this.unselectElement(value['count'], key)}/>}
                 />
             );
             count++;
@@ -518,7 +519,7 @@ export class ElementsDashboard extends Component {
                 'allDay': true,
                 'url': value.url,
                 'type': value.element_type,
-                count,
+                'count': count,
                 'id': value.id,
                 'status': 0,
             }


### PR DESCRIPTION
## Objetivos

- Se deben poder realizar acciones de forma masiva sobre múltiples propuestas, como marcarlas como compradas, reprocesarlas o eliminarlas.

## Comportamiento nuevo

- Al entrar en el modo de selección múltiple con el botón `SELECT MODE`, aparecen dos botones nuevos bajo la lista de elementos seleccionados:
    - `BUY`: Cambia el estado de los elementos seleccionados a `Bought`.
    - `REPROCESS`: Inicia el reprocesado de los elementos seleccionados.
    - `DELETE`: Elimina permanentemente del sistema los elementos seleccionados .
- El sistema advierte al usuario de las consecuencias de la acción.
- Los elementos candidatos que no se ajusten al perfil requerido por la acción, no se verán afectados por la misma.

## Relacionado

Closes #320

## Checklist

- [x] Test code

![Captura de pantalla de 2019-08-21 12-45-12](https://user-images.githubusercontent.com/49635897/63425747-92ecee80-c411-11e9-8a5d-a294693c0103.png)