### PR TITLE
Se ha añadido un indicador de estado a los históricos en el calendario

### DIFF
--- a/src/components/ElementsDashboardCalendar/index.js
+++ b/src/components/ElementsDashboardCalendar/index.js
@@ -536,7 +536,7 @@ class ElementsDashboard extends Component {
         let current_type = e.type;
         let class_name = "";
 
-        if (current_type == 'proposal') {
+        if (current_type == 'proposal' || current_type == 'historical') {
             class_name = current_type + e.status['lite'];
         }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -57,3 +57,59 @@
     padding: 0px 1px 1px 1px;
   }
 }
+
+/* Historical status icon in calendar */
+
+.historicalOK {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #4caf50;
+    padding: 0px 1px 1px 1px;
+  }
+}
+
+.historicalKO {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #f44336;
+    padding: 0px 1px 1px 1px;
+  }
+}
+
+.historicalWIP {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #ffb74d;
+    padding: 0px 1px 1px 1px;
+  }
+}
+
+.historicalRUN {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #ffb74d;
+    padding: 0px 1px 1px 1px;
+  }
+}
+
+.historicalERR {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #f44336;
+    padding: 0px 1px 1px 1px;
+  }
+}
+
+.historicalBUY {
+  :after {
+    float:right;
+    content: "\25CF";
+    color: #2196f3;
+    padding: 0px 1px 1px 1px;
+  }
+}


### PR DESCRIPTION
## Nuevo comportamiento
- Se han añadido iconos de color para representar visualmente el estado de los elementos de tipo "Histórico" en el calendario.
- El código de color es el mismo que usan los elementos de tiop "Propuesta":
    - Verde: OK
    - Naranja: Pendiente / Procesando 
    - Rojo: Error

![Captura de pantalla de 2019-12-10 15-07-34](https://user-images.githubusercontent.com/49635897/70536372-d7d29780-1b5e-11ea-8da2-b5242bd2d357.png)