### PR TITLE
Actualización de la imagen de Node7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use latest node image
-FROM node:7.10.0
+FROM node:7.10.1-stretch
 
 ARG ORAKWLUM_FRONTEND_VERSION=master
 
@@ -25,9 +25,10 @@ RUN ln -s /opt/orakWlum-frontend /opt/oraKWlum-frontend
 RUN chmod -R +r /var/www
 
 # Install nginx
-RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
-RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN rm -rf /etc/apt/sources.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backports.list
+RUN sed -i '/deb http:\/\/archive.debian.org\/debian stretch-updates main/d' /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update
 RUN apt-get -y install nginx
 


### PR DESCRIPTION
## Objetivos

- Actualizar la estructura del `docker` para poder ejecutar sin problemas el frontal en instalaciones recientes.
- La actualización se debe a que los repositorios de la versión anterior de Debian (jessie) ya no están disponibles y dan problemas a la hora de desplegar el frontal dockerizado.

## Comportamiento antiguo

- Se usa la imagen `node7.10.0` basada en Debian 8.

## Comportamiento nuevo

- Se usa la imagen `node7.10.1` basada en Debian 9.
